### PR TITLE
Fix untyped tool parameter schemas rejected by strict MCP clients

### DIFF
--- a/python/fxhoudinimcp/_types.py
+++ b/python/fxhoudinimcp/_types.py
@@ -1,0 +1,11 @@
+"""Shared type aliases for MCP tool parameters.
+
+Tool parameters must not be annotated with bare ``Any``: pydantic renders
+``Any`` as a schema with no ``type`` (e.g. ``{"title": "Value"}``), which
+strict MCP clients such as OpenCode reject during JSON Schema conversion.
+"""
+
+from __future__ import annotations
+
+# A JSON-compatible parameter or attribute value: scalar or flat list.
+Value = bool | int | float | str | list[bool | int | float | str]

--- a/python/fxhoudinimcp/tools/context.py
+++ b/python/fxhoudinimcp/tools/context.py
@@ -83,7 +83,7 @@ async def get_selection(ctx: Context) -> dict:
 @mcp.tool()
 async def set_selection(
     ctx: Context,
-    node_paths: Optional[list] = None,
+    node_paths: Optional[list[str]] = None,
 ) -> dict:
     """Set the node selection.
 

--- a/python/fxhoudinimcp/tools/geometry.py
+++ b/python/fxhoudinimcp/tools/geometry.py
@@ -9,6 +9,7 @@ from typing import Any
 from mcp.server.fastmcp import Context
 
 # Internal
+from fxhoudinimcp._types import Value
 from fxhoudinimcp.server import mcp, _get_bridge
 
 
@@ -134,7 +135,7 @@ async def set_detail_attrib(
     ctx: Context,
     node_path: str,
     attrib_name: str,
-    value: Any,
+    value: Value,
 ) -> dict:
     """Set a detail attribute on a SOP node.
 

--- a/python/fxhoudinimcp/tools/lops.py
+++ b/python/fxhoudinimcp/tools/lops.py
@@ -9,6 +9,7 @@ from typing import Any
 from mcp.server.fastmcp import Context
 
 # Internal
+from fxhoudinimcp._types import Value
 from fxhoudinimcp.server import mcp, _get_bridge
 
 
@@ -203,7 +204,7 @@ async def set_usd_attribute(
     node_path: str,
     prim_path: str,
     attr_name: str,
-    value: Any,
+    value: Value,
 ) -> dict:
     """Set a USD attribute value via an inline Python LOP.
 

--- a/python/fxhoudinimcp/tools/nodes.py
+++ b/python/fxhoudinimcp/tools/nodes.py
@@ -22,7 +22,7 @@ async def create_node(
     parent_path: str,
     node_type: str,
     name: Optional[str] = None,
-    position: Optional[list] = None,
+    position: Optional[list[float]] = None,
 ) -> dict:
     """Create a node inside a parent network.
 
@@ -299,7 +299,9 @@ async def disconnect_node(
 
 
 @mcp.tool()
-async def reorder_inputs(ctx: Context, node_path: str, new_order: list) -> dict:
+async def reorder_inputs(
+    ctx: Context, node_path: str, new_order: list[int]
+) -> dict:
     """Reorder the input connections of a node.
 
     Args:

--- a/python/fxhoudinimcp/tools/parameters.py
+++ b/python/fxhoudinimcp/tools/parameters.py
@@ -13,6 +13,7 @@ from typing import Any
 from mcp.server.fastmcp import Context
 
 # Internal
+from fxhoudinimcp._types import Value
 from fxhoudinimcp.server import mcp, _get_bridge
 
 
@@ -39,7 +40,7 @@ async def get_parameter(ctx: Context, node_path: str, parm_name: str) -> dict:
 
 @mcp.tool()
 async def set_parameter(
-    ctx: Context, node_path: str, parm_name: str, value: Any
+    ctx: Context, node_path: str, parm_name: str, value: Value
 ) -> dict:
     """Set a parameter value.
 
@@ -236,7 +237,7 @@ async def create_spare_parameter(
     parm_name: str,
     parm_type: str,
     label: str,
-    default_value: Any = None,
+    default_value: Value | None = None,
     min_val: float | None = None,
     max_val: float | None = None,
 ) -> dict:

--- a/python/fxhoudinimcp/tools/scene.py
+++ b/python/fxhoudinimcp/tools/scene.py
@@ -132,7 +132,7 @@ async def export_file(
     ctx: Context,
     node_path: str,
     file_path: str,
-    frame_range: Optional[list] = None,
+    frame_range: Optional[list[float]] = None,
 ) -> dict:
     """Export a node's output to a file on disk.
 

--- a/python/fxhoudinimcp/tools/workflows.py
+++ b/python/fxhoudinimcp/tools/workflows.py
@@ -9,7 +9,7 @@ chain building, and render configuration.
 from __future__ import annotations
 
 # Built-in
-from typing import Optional
+from typing import Any, Optional
 
 # Third-party
 from mcp.server.fastmcp import Context
@@ -152,7 +152,7 @@ async def create_material(
     ctx: Context,
     name: str = "material1",
     mat_type: str = "principled",
-    base_color: Optional[list] = None,
+    base_color: Optional[list[float]] = None,
     roughness: float = 0.5,
     metallic: float = 0.0,
     opacity: float = 1.0,
@@ -206,7 +206,7 @@ async def assign_material(
 async def build_sop_chain(
     ctx: Context,
     parent_path: str = "/obj/geo1",
-    steps: Optional[list] = None,
+    steps: Optional[list[dict[str, Any]]] = None,
 ) -> dict:
     """Build a sequential chain of SOP nodes wired together in a single call.
 
@@ -241,7 +241,7 @@ async def setup_render(
     renderer: str = "karma",
     camera: Optional[str] = None,
     output_path: str = "$HIP/render/output.$F4.exr",
-    resolution: Optional[list] = None,
+    resolution: Optional[list[int]] = None,
     samples: int = 64,
     name: str = "render1",
 ) -> dict:

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,45 @@
+"""Regression tests for generated tool JSON schemas.
+
+Strict MCP clients (e.g. OpenCode) reject schemas that carry no concrete
+type information, which happens when a tool parameter is annotated with
+bare ``Any`` (GitHub issue #1).
+"""
+
+from __future__ import annotations
+
+# Third-party
+import pytest
+
+# Internal
+import fxhoudinimcp.tools  # noqa: F401  (registers all tools on import)
+from fxhoudinimcp.server import mcp
+
+_TYPED_KEYS = {"type", "anyOf", "oneOf", "allOf", "$ref", "enum", "const"}
+
+
+def _assert_typed(schema: object, path: str) -> None:
+    """Recursively assert that every subschema declares a concrete type."""
+    if isinstance(schema, bool):
+        return
+    assert isinstance(schema, dict), f"{path}: expected a schema, got {schema!r}"
+    if not _TYPED_KEYS & schema.keys():
+        pytest.fail(f"Untyped schema at {path}: {schema}")
+    for key in ("anyOf", "oneOf", "allOf"):
+        for index, sub in enumerate(schema.get(key, [])):
+            _assert_typed(sub, f"{path}.{key}[{index}]")
+    for name, sub in schema.get("properties", {}).items():
+        _assert_typed(sub, f"{path}.properties.{name}")
+    for name, sub in schema.get("$defs", {}).items():
+        _assert_typed(sub, f"{path}.$defs.{name}")
+    if isinstance(schema.get("items"), dict):
+        _assert_typed(schema["items"], f"{path}.items")
+    if isinstance(schema.get("additionalProperties"), dict):
+        _assert_typed(schema["additionalProperties"], f"{path}.additionalProperties")
+
+
+@pytest.mark.asyncio
+async def test_all_tool_schemas_are_typed():
+    tools = await mcp.list_tools()
+    assert tools, "no tools registered"
+    for tool in tools:
+        _assert_typed(tool.inputSchema, tool.name)


### PR DESCRIPTION
## Summary

Closes #1.

OpenCode (and other strict MCP clients) failed to convert this server's tool schemas with errors like:

```
JSON schema conversion failed:
Unrecognized schema: {"title":"Value"}
Unrecognized schema: {"default":null,"title":"Default Value"}
```

These come from tool parameters annotated with bare `Any` (and unparameterized `list`), which pydantic renders as a schema with no `type` field.

## Changes

- Added `fxhoudinimcp._types.Value`, a JSON-compatible union (`bool | int | float | str | list[...]`), and used it for `set_parameter.value`, `set_detail_attrib.value`, `set_usd_attribute.value`, and `create_spare_parameter.default_value` — the four schemas reported in the issue.
- Typed the remaining bare `list` parameters found by the new test: `export_file.frame_range`, `create_node.position`, `reorder_inputs.new_order`, `set_selection.node_paths`, `create_material.base_color`, `build_sop_chain.steps`, `setup_render.resolution`.
- Added `tests/test_schemas.py`, a regression test that walks every generated tool schema and fails on any subschema without concrete type information (it failed on the old code, passes now).

## Testing

- `pytest tests/` — 75 passed.
- `ruff check` clean on the new files (pre-existing UP/I001 findings in touched files left as-is to keep the diff focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)