### PR TITLE
Make automatic node layout a toggle via FXHOUDINIMCP_AUTO_LAYOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Once connected, your AI assistant can:
 | `HOUDINI_PORT` | `8100` | Houdini hwebserver port |
 | `FXHOUDINIMCP_PORT` | `8100` | Port for the Houdini plugin to listen on |
 | `FXHOUDINIMCP_AUTOSTART` | `1` | Set to `0` to disable auto-start |
+| `FXHOUDINIMCP_AUTO_LAYOUT` | `1` | Set to `0` to disable automatic node layout (preserves manual layouts) |
 | `MCP_TRANSPORT` | `stdio` | MCP transport (`stdio` or `streamable-http`) |
 | `LOG_LEVEL` | `INFO` | Logging level |
 

--- a/docs/how-to/configuration.md
+++ b/docs/how-to/configuration.md
@@ -8,6 +8,7 @@
 | `HOUDINI_PORT` | `8100` | Houdini hwebserver port |
 | `FXHOUDINIMCP_PORT` | `8100` | Port for the Houdini plugin to listen on |
 | `FXHOUDINIMCP_AUTOSTART` | `1` | Set to `0` to disable auto-start |
+| `FXHOUDINIMCP_AUTO_LAYOUT` | `1` | Set to `0` to disable automatic node layout |
 | `MCP_TRANSPORT` | `stdio` | MCP transport (`stdio` or `streamable-http`) |
 | `LOG_LEVEL` | `INFO` | Logging level |
 
@@ -29,6 +30,34 @@ If an assistant cannot reach Houdini, use `get_houdini_connection_status` to
 return structured diagnostics without raising a tool error. If port `8100` is
 owned by a different Houdini process, either close that process or set both
 `FXHOUDINIMCP_PORT` and `HOUDINI_PORT` to a matching free port.
+
+## Auto-Layout
+
+By default, tools tidy the network editor as they work: node-creation handlers
+and workflow tools call `layoutChildren()` on the parent network, and the
+server instructions tell assistants to call `layout_children` frequently. This
+re-arranges *all* nodes in the affected network — including ones you placed by
+hand.
+
+To preserve your manual layouts, disable auto-layout:
+
+``` shell
+export FXHOUDINIMCP_AUTO_LAYOUT=0
+```
+
+Set it both in the MCP client environment (where `python -m fxhoudinimcp`
+runs) and in the Houdini environment (e.g. `houdini.env`), since each process
+reads it independently. Inside a running Houdini session you can also toggle
+it without restarting:
+
+``` python
+hou.putenv("FXHOUDINIMCP_AUTO_LAYOUT", "0")
+```
+
+When disabled, the server instructions tell assistants never to move nodes,
+the `layout_children` tool becomes a no-op, and the Houdini-side handlers skip
+every automatic `layoutChildren()` call. Newly created nodes keep the position
+Houdini assigns at creation time.
 
 ## Transport Modes
 

--- a/houdini/scripts/python/fxhoudinimcp_server/config.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/config.py
@@ -1,0 +1,31 @@
+"""Runtime configuration flags for the in-Houdini MCP server."""
+
+from __future__ import annotations
+
+# Built-in
+import os
+
+# Third-party
+import hou
+
+_FALSY = {"0", "false", "off", "no"}
+
+
+def auto_layout_enabled() -> bool:
+    """Whether handlers may auto-arrange nodes in the network editor.
+
+    Reads ``FXHOUDINIMCP_AUTO_LAYOUT`` via ``hou.getenv`` first (so it can
+    be set in houdini.env or toggled at runtime with ``hou.putenv``), then
+    falls back to the process environment. Defaults to enabled; set to
+    ``0`` to preserve existing node layouts.
+    """
+    value = hou.getenv("FXHOUDINIMCP_AUTO_LAYOUT")
+    if value is None:
+        value = os.environ.get("FXHOUDINIMCP_AUTO_LAYOUT", "1")
+    return value.strip().lower() not in _FALSY
+
+
+def layout_if_enabled(node: hou.Node) -> None:
+    """Lay out *node*'s children unless auto-layout is disabled."""
+    if auto_layout_enabled():
+        node.layoutChildren()

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/chop_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/chop_handlers.py
@@ -13,6 +13,7 @@ from typing import Any
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 
@@ -31,7 +32,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/cop_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/cop_handlers.py
@@ -13,6 +13,7 @@ import logging
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
@@ -13,6 +13,7 @@ from typing import Any
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 # USD modules -- may not be available in all Houdini configurations
@@ -30,7 +31,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/material_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/material_handlers.py
@@ -13,6 +13,7 @@ from typing import Any
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 
@@ -31,7 +32,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/node_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/node_handlers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import auto_layout_enabled, layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 
@@ -38,7 +39,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:
@@ -693,6 +694,13 @@ def layout_children(parent_path: str, spacing: float = None) -> dict:
         parent_path: Path to the parent network.
         spacing: Optional spacing multiplier between nodes.
     """
+    if not auto_layout_enabled():
+        return {
+            "success": False,
+            "skipped": True,
+            "reason": "Auto-layout is disabled (FXHOUDINIMCP_AUTO_LAYOUT=0).",
+        }
+
     parent = _get_node(parent_path)
 
     if spacing is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/scene_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/scene_handlers.py
@@ -13,6 +13,7 @@ import os
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 
@@ -23,7 +24,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/vex_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/vex_handlers.py
@@ -13,6 +13,7 @@ import re
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 
@@ -103,7 +104,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/workflow_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/workflow_handlers.py
@@ -14,6 +14,7 @@ from typing import Any
 import hou
 
 # Internal
+from fxhoudinimcp_server.config import layout_if_enabled
 from fxhoudinimcp_server.dispatcher import register_handler
 
 
@@ -32,7 +33,7 @@ def _focus_network_editor(node: hou.Node) -> None:
     try:
         parent = node.parent()
         if parent is not None:
-            parent.layoutChildren()
+            layout_if_enabled(parent)
         for pane_tab in hou.ui.paneTabs():
             if pane_tab.type() == hou.paneTabType.NetworkEditor:
                 if parent is not None:
@@ -133,7 +134,7 @@ def _setup_pyro_sim_sop(
     except Exception:
         pass
 
-    geo.layoutChildren()
+    layout_if_enabled(geo)
     _focus_network_editor(filecache)
     print("[workflow] SOP-level Pyro setup complete")
 
@@ -250,8 +251,8 @@ def _setup_pyro_sim_dop(
     except Exception:
         pass
 
-    geo.layoutChildren()
-    dopnet.layoutChildren()
+    layout_if_enabled(geo)
+    layout_if_enabled(dopnet)
     _focus_network_editor(filecache)
     print("[workflow] DOP-level Pyro setup complete")
 
@@ -469,8 +470,8 @@ def _setup_rbd_sim(
 
     # -- Step 10: Layout
     print("[workflow] Laying out nodes")
-    geo.layoutChildren()
-    dopnet.layoutChildren()
+    layout_if_enabled(geo)
+    layout_if_enabled(dopnet)
     _focus_network_editor(filecache)
 
     print(f"[workflow] RBD simulation '{name}' setup complete")
@@ -603,8 +604,8 @@ def _setup_flip_sim(
 
     # -- Step 10: Layout
     print("[workflow] Laying out nodes")
-    geo.layoutChildren()
-    dopnet.layoutChildren()
+    layout_if_enabled(geo)
+    layout_if_enabled(dopnet)
     _focus_network_editor(filecache)
 
     print(f"[workflow] FLIP simulation '{name}' setup complete")
@@ -724,7 +725,7 @@ def _setup_vellum_sim(
 
     # -- Step 6: Layout
     print("[workflow] Laying out nodes")
-    geo.layoutChildren()
+    layout_if_enabled(geo)
     _focus_network_editor(filecache)
 
     print(f"[workflow] Vellum simulation '{name}' ({sim_type}) setup complete")
@@ -815,7 +816,7 @@ def _create_material(
     else:
         raise ValueError(f"Unknown mat_type '{mat_type}'. Must be 'principled' or 'materialx'.")
 
-    mat.layoutChildren()
+    layout_if_enabled(mat)
     _focus_network_editor(shader)
 
     print(f"[workflow] Material '{name}' created at {shader_path}")
@@ -894,7 +895,7 @@ def _assign_material(
     except Exception:
         pass
 
-    sop_parent.layoutChildren()
+    layout_if_enabled(sop_parent)
     _focus_network_editor(mat_sop)
 
     print(f"[workflow] Material assigned: {mat_sop.path()} -> {material_path}")
@@ -981,7 +982,7 @@ def _build_sop_chain(
 
     # Layout
     print("[workflow] Laying out nodes")
-    parent.layoutChildren()
+    layout_if_enabled(parent)
     if prev_node is not None:
         _focus_network_editor(prev_node)
 
@@ -1094,7 +1095,7 @@ def _setup_render(
             break
 
     # Layout
-    out.layoutChildren()
+    layout_if_enabled(out)
     _focus_network_editor(rop)
 
     print(f"[workflow] Render setup '{name}' complete ({renderer})")

--- a/python/fxhoudinimcp/_loader.py
+++ b/python/fxhoudinimcp/_loader.py
@@ -5,13 +5,31 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 
+from fxhoudinimcp.config import auto_layout_enabled
+
 _MD_DIR = Path(__file__).parent / "prompts" / "markdown"
+
+_LAYOUT_GUIDANCE_ON = (
+    "Call layout_children frequently — after every batch of 3-5 new nodes, "
+    "not just at the end. A tidy graph lets the user follow along in real "
+    "time."
+)
+_LAYOUT_GUIDANCE_OFF = (
+    "Auto-layout is disabled (FXHOUDINIMCP_AUTO_LAYOUT=0). NEVER call "
+    "layout_children or move existing nodes — the user manages node "
+    "placement manually. Leave node positions exactly as they are."
+)
 
 
 @lru_cache(maxsize=None)
 def _read(name: str) -> str:
     """Read a markdown file once and cache it for the process lifetime."""
     return (_MD_DIR / name).read_text(encoding="utf-8")
+
+
+def _layout_guidance() -> str:
+    """Layout instruction matching the current auto-layout toggle."""
+    return _LAYOUT_GUIDANCE_ON if auto_layout_enabled() else _LAYOUT_GUIDANCE_OFF
 
 
 def load_markdown(name: str, **kwargs: str) -> str:
@@ -23,21 +41,22 @@ def load_markdown(name: str, **kwargs: str) -> str:
     Args:
         name: Filename (with .md extension) inside the ``markdown/`` directory.
         **kwargs: Values to substitute into ``{placeholder}`` tokens in the
-            markdown text.  The special key ``network_housekeeping`` is
-            automatically populated from ``network_housekeeping.md`` if not
-            explicitly provided.
+            markdown text.  The special keys ``network_housekeeping`` and
+            ``layout_guidance`` are automatically populated if not explicitly
+            provided.
 
     Returns:
         The formatted markdown string.
     """
     text = _read(name)
 
+    if "{layout_guidance}" in text and "layout_guidance" not in kwargs:
+        kwargs["layout_guidance"] = _layout_guidance()
+    if "{network_housekeeping}" in text and "network_housekeeping" not in kwargs:
+        kwargs["network_housekeeping"] = _read(
+            "network_housekeeping.md"
+        ).format(layout_guidance=_layout_guidance())
     if kwargs:
-        if (
-            "network_housekeeping" not in kwargs
-            and "{network_housekeeping}" in text
-        ):
-            kwargs["network_housekeeping"] = _read("network_housekeeping.md")
         text = text.format(**kwargs)
 
     return text

--- a/python/fxhoudinimcp/config.py
+++ b/python/fxhoudinimcp/config.py
@@ -1,0 +1,18 @@
+"""Runtime configuration flags read from environment variables."""
+
+from __future__ import annotations
+
+# Built-in
+import os
+
+_FALSY = {"0", "false", "off", "no"}
+
+
+def auto_layout_enabled() -> bool:
+    """Whether tools may auto-arrange nodes in the network editor.
+
+    Controlled by the ``FXHOUDINIMCP_AUTO_LAYOUT`` environment variable.
+    Defaults to enabled; set to ``0`` to preserve existing node layouts.
+    """
+    value = os.getenv("FXHOUDINIMCP_AUTO_LAYOUT", "1")
+    return value.strip().lower() not in _FALSY

--- a/python/fxhoudinimcp/prompts/markdown/network_housekeeping.md
+++ b/python/fxhoudinimcp/prompts/markdown/network_housekeeping.md
@@ -2,4 +2,4 @@
 
 - Call log_status at the start of every major step (creating geometry, wiring the chain, setting up materials, etc.) so the user can see what you are doing in Houdini's status bar without inspecting tool call logs. Keep messages short: "Creating source geometry...", "Wiring SOP chain...", "Done — display flag set on output node."
 - Call set_current_network on the parent network you are building in so the user can see your work in the network editor. Do this BEFORE you start creating nodes, and again whenever you move to a different network level.
-- Call layout_children frequently — after every batch of 3-5 new nodes, not just at the end. A tidy graph lets the user follow along in real time.
+- {layout_guidance}

--- a/python/fxhoudinimcp/prompts/markdown/server_instructions.md
+++ b/python/fxhoudinimcp/prompts/markdown/server_instructions.md
@@ -142,5 +142,5 @@ When to look: (1) unsure if a node exists, (2) need parameter details, (3) need 
 *   After EVERY create\_wrangle or set\_wrangle\_code, immediately call validate\_vex. Do not proceed until it reports no errors.
 *   build\_sop\_chain wires a whole chain at once. Prefer it over individual create\_node calls for linear SOP chains.
 *   NEVER hardcode tweakable values. Create a controller null ('CTRL') with spare parameters.
-*   Call layout\_children after every batch of nodes, not just at the end.
+*   {layout_guidance}
 *   When a workflow tool exists (setup\_pyro\_sim, setup\_rbd\_sim, etc.), use it instead of building from scratch.

--- a/python/fxhoudinimcp/tools/nodes.py
+++ b/python/fxhoudinimcp/tools/nodes.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 from mcp.server.fastmcp import Context
 
 # Internal
+from fxhoudinimcp.config import auto_layout_enabled
 from fxhoudinimcp.server import mcp, _get_bridge
 
 
@@ -361,11 +362,21 @@ async def layout_children(
 ) -> dict:
     """Auto-layout children of a network node.
 
+    Does nothing when auto-layout is disabled via FXHOUDINIMCP_AUTO_LAYOUT=0.
+
     Args:
         ctx: MCP context.
         parent_path: Parent network path.
         spacing: Spacing multiplier between nodes.
     """
+    if not auto_layout_enabled():
+        return {
+            "skipped": True,
+            "reason": (
+                "Auto-layout is disabled (FXHOUDINIMCP_AUTO_LAYOUT=0). "
+                "Leave node positions as they are; do not retry."
+            ),
+        }
     bridge = _get_bridge(ctx)
     params: dict = {"parent_path": parent_path}
     if spacing is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,98 @@
+"""Tests for the FXHOUDINIMCP_AUTO_LAYOUT toggle (GitHub issue #2)."""
+
+from __future__ import annotations
+
+# Built-in
+import os
+import sys
+from unittest.mock import MagicMock
+
+# Third-party
+import pytest
+
+# Mock Houdini modules before importing the in-Houdini server package
+sys.modules.setdefault("hou", MagicMock())
+sys.modules.setdefault("hdefereval", MagicMock())
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "houdini", "scripts", "python"))
+
+# Internal
+import fxhoudinimcp_server.config as houdini_config  # noqa: E402
+
+from fxhoudinimcp._loader import load_markdown  # noqa: E402
+from fxhoudinimcp.config import auto_layout_enabled  # noqa: E402
+from fxhoudinimcp.tools.nodes import layout_children  # noqa: E402
+
+
+class TestAutoLayoutFlag:
+    def test_default_enabled(self, monkeypatch):
+        monkeypatch.delenv("FXHOUDINIMCP_AUTO_LAYOUT", raising=False)
+        assert auto_layout_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "OFF", " no "])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("FXHOUDINIMCP_AUTO_LAYOUT", value)
+        assert auto_layout_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "on", "yes"])
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("FXHOUDINIMCP_AUTO_LAYOUT", value)
+        assert auto_layout_enabled() is True
+
+
+class TestLayoutGuidance:
+    def test_instructions_promote_layout_when_enabled(self, monkeypatch):
+        monkeypatch.delenv("FXHOUDINIMCP_AUTO_LAYOUT", raising=False)
+        text = load_markdown("server_instructions.md")
+        assert "Call layout_children frequently" in text
+
+    def test_instructions_forbid_layout_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("FXHOUDINIMCP_AUTO_LAYOUT", "0")
+        text = load_markdown("server_instructions.md")
+        assert "NEVER call layout_children" in text
+        assert "Call layout_children frequently" not in text
+
+    def test_housekeeping_block_follows_toggle(self, monkeypatch):
+        monkeypatch.setenv("FXHOUDINIMCP_AUTO_LAYOUT", "0")
+        text = load_markdown(
+            "procedural_modeling.md",
+            description="a rock",
+            output_context="/obj",
+        )
+        assert "NEVER call layout_children" in text
+
+
+class TestLayoutChildrenTool:
+    @pytest.mark.asyncio
+    async def test_skipped_when_disabled(self, monkeypatch, mock_ctx, mock_bridge):
+        monkeypatch.setenv("FXHOUDINIMCP_AUTO_LAYOUT", "0")
+        result = await layout_children(mock_ctx, parent_path="/obj/geo1")
+        assert result["skipped"] is True
+        mock_bridge.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_executes_when_enabled(self, monkeypatch, mock_ctx, mock_bridge):
+        monkeypatch.delenv("FXHOUDINIMCP_AUTO_LAYOUT", raising=False)
+        await layout_children(mock_ctx, parent_path="/obj/geo1")
+        mock_bridge.execute.assert_called_once_with(
+            "nodes.layout_children", {"parent_path": "/obj/geo1"}
+        )
+
+
+class TestHoudiniSideConfig:
+    def test_layout_if_enabled_skips_when_disabled(self, monkeypatch):
+        monkeypatch.setattr(houdini_config.hou, "getenv", lambda name: "0")
+        node = MagicMock()
+        houdini_config.layout_if_enabled(node)
+        node.layoutChildren.assert_not_called()
+
+    def test_layout_if_enabled_lays_out_by_default(self, monkeypatch):
+        monkeypatch.setattr(houdini_config.hou, "getenv", lambda name: None)
+        monkeypatch.delenv("FXHOUDINIMCP_AUTO_LAYOUT", raising=False)
+        node = MagicMock()
+        houdini_config.layout_if_enabled(node)
+        node.layoutChildren.assert_called_once()
+
+    def test_process_env_fallback(self, monkeypatch):
+        monkeypatch.setattr(houdini_config.hou, "getenv", lambda name: None)
+        monkeypatch.setenv("FXHOUDINIMCP_AUTO_LAYOUT", "0")
+        assert houdini_config.auto_layout_enabled() is False


### PR DESCRIPTION
## Summary

Closes #2.

The server previously forced network layout everywhere: handlers called `layoutChildren()` after every node creation, workflow tools laid out entire networks (including shared ones like `/mat` and `/out`), and the server instructions told assistants to "call layout_children after every batch of 3-5 nodes". `layoutChildren()` moves **all** children of a network, so this destroyed manually arranged node graphs in existing scenes.

## Changes

New environment variable `FXHOUDINIMCP_AUTO_LAYOUT` (default `1`). Setting it to `0` disables automatic layout at all three layers:

1. **Prompt guidance** — the server instructions and the network-housekeeping block injected into all workflow prompts switch from "call layout_children frequently" to "NEVER call layout_children or move existing nodes". The guidance is substituted at load time via a `{layout_guidance}` placeholder.
2. **MCP tool** — `layout_children` short-circuits into a no-op with an explicit skip notice, so even an assistant that ignores instructions cannot re-arrange nodes.
3. **Houdini-side handlers** — a new `fxhoudinimcp_server.config.layout_if_enabled()` helper guards the `_focus_network_editor` helpers in all handler modules and every explicit `layoutChildren()` call in the workflow builders. The Houdini process reads the variable through `hou.getenv` first, so it can be set in `houdini.env` or toggled live with `hou.putenv("FXHOUDINIMCP_AUTO_LAYOUT", "0")` — no restart needed.

Since the MCP server and Houdini are separate processes, the variable is read independently by each; the docs call this out. Default behavior is unchanged.

## Testing

- `pytest tests/` — 91 passed (17 new tests covering flag parsing on both sides, prompt guidance switching, tool short-circuit, and the Houdini-side guard).
- Verified the rendered server instructions in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)