### PR TITLE
User-facing scenario tests, 100% command coverage, cross-platform runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,9 @@ Unit tests mock `hou` and run anywhere. The integration suite in
 simulation, animation, lookdev) — and prints per-command timing and
 coverage reports; it is skipped automatically when `hou` is not
 available. `tests/integration/perf_sweep.py` benchmarks handlers on
-large scenes.
+large scenes, and `python tests/integration/bridge_e2e.py` validates the
+full HTTP transport (real hwebserver in hython driven by the MCP
+server's own bridge).
 
 ### How It Works
 

--- a/README.md
+++ b/README.md
@@ -275,14 +275,19 @@ ruff check python/
 pytest
 
 # Run integration tests inside a real Houdini (requires a license seat;
-# uses the newest installed Houdini, override with the HYTHON env var)
-tests/run_integration.ps1
+# uses the newest installed Houdini, override with the HYTHON env var).
+# Works on Windows, macOS, and Linux:
+python tests/run_integration.py
+# Convenience wrappers: tests/run_integration.ps1 / tests/run_integration.sh
 ```
 
 Unit tests mock `hou` and run anywhere. The integration suite in
-`tests/integration/` executes every handler against live Houdini via
-`hython` and prints a per-command timing report; it is skipped
-automatically when `hou` is not available.
+`tests/integration/` executes all 173 commands against live Houdini via
+`hython` — including end-to-end user scenarios (procedural modeling,
+simulation, animation, lookdev) — and prints per-command timing and
+coverage reports; it is skipped automatically when `hou` is not
+available. `tests/integration/perf_sweep.py` benchmarks handlers on
+large scenes.
 
 ### How It Works
 

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/chop_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/chop_handlers.py
@@ -76,7 +76,7 @@ def _get_chop_data(
         num_samples = track.numSamples()
         clip = track.clip()
         sample_rate = clip.sampleRate()
-        start_idx = clip.start()
+        start_idx = int(clip.sampleRange()[0])
         end_idx = start_idx + num_samples - 1
 
         # Compute min/max values
@@ -112,7 +112,7 @@ def _get_chop_data(
         # Apply start/end range if provided
         if start is not None or end is not None:
             clip = track.clip()
-            clip_start = clip.start()
+            clip_start = int(clip.sampleRange()[0])
             s = (start - clip_start) if start is not None else 0
             e = (end - clip_start + 1) if end is not None else len(all_samples)
             s = max(0, s)

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/cop_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/cop_handlers.py
@@ -351,12 +351,13 @@ def list_cop_node_types(filter: str = None) -> dict:
     Args:
         filter: Optional substring filter for node type names.
     """
-    # Try Cop2 category (standard COPs and Copernicus)
+    # Copernicus ("Cop", Houdini 20.5+) is what create_cop_node creates
+    # inside a copnet; fall back to legacy Cop2 on older builds.
     cop_types = []
 
     try:
-        cop2_category = hou.cop2NodeTypeCategory()
-        for type_name, node_type in cop2_category.nodeTypes().items():
+        category = hou.nodeTypeCategories().get("Cop") or hou.cop2NodeTypeCategory()
+        for type_name, node_type in category.nodeTypes().items():
             if filter and filter.lower() not in type_name.lower():
                 continue
             type_info = {

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
@@ -842,8 +842,8 @@ def _create_light(
 
     node = parent.createNode(lop_type, node_name=name)
 
-    # Set intensity
-    intensity_parm = node.parm("xn__inputsintensity_i0b")
+    # Set intensity ("inputs:intensity" punycodes to xn__inputsintensity_i0a)
+    intensity_parm = node.parm("xn__inputsintensity_i0a")
     if intensity_parm is None:
         intensity_parm = node.parm("intensity")
     if intensity_parm is not None:
@@ -852,7 +852,7 @@ def _create_light(
     # Set color
     if color is not None and len(color) >= 3:
         for i, suffix in enumerate(["r", "g", "b"]):
-            parm = node.parm(f"xn__inputscolor_{suffix}0b")
+            parm = node.parm(f"xn__inputscolor_zta{suffix}")
             if parm is None:
                 parm = node.parm(f"color{suffix}")
             if parm is not None:
@@ -1097,26 +1097,33 @@ def _create_light_rig(
         )
 
     created_nodes: list[str] = []
+    previous: hou.Node | None = None
 
     for light_def in preset_config:
         lop_type = light_def["type"]
         light_name = light_def.get("name")
         node = parent.createNode(lop_type, node_name=light_name)
 
-        # Set intensity with multiplier
+        # Chain the lights so the last node's stage contains the whole rig.
+        if previous is not None:
+            node.setInput(0, previous)
+        previous = node
+
+        # Set intensity with multiplier. USD light parms are punycoded
+        # ("inputs:intensity" -> xn__inputsintensity_i0a).
         base_intensity = light_def.get("intensity", 1.0)
         final_intensity = base_intensity * intensity_mult
-        intensity_parm = node.parm("xn__inputsintensity_i0b")
+        intensity_parm = node.parm("xn__inputsintensity_i0a")
         if intensity_parm is None:
             intensity_parm = node.parm("intensity")
         if intensity_parm is not None:
             intensity_parm.set(final_intensity)
 
-        # Set color
+        # Set color ("inputs:color" components -> xn__inputscolor_zta{r,g,b})
         light_color = light_def.get("color")
         if light_color:
             for i, suffix in enumerate(["r", "g", "b"]):
-                parm = node.parm(f"xn__inputscolor_{suffix}0b")
+                parm = node.parm(f"xn__inputscolor_zta{suffix}")
                 if parm is None:
                     parm = node.parm(f"color{suffix}")
                 if parm is not None:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
@@ -1010,7 +1010,8 @@ def _set_light_properties(
         + "\n".join(set_lines)
     )
 
-    python_node = parent.createNode("python", node_name="set_light_props_auto")
+    # "pythonscript" is the LOP type name; "python" does not exist here.
+    python_node = parent.createNode("pythonscript", node_name="set_light_props_auto")
     python_node.setInput(0, node)
     python_node.parm("python").set(snippet)
     python_node.moveToGoodPosition()

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
@@ -499,8 +499,9 @@ def _set_usd_attribute(
 
     parent = node.parent()
 
-    # Create a Python LOP to set the attribute
-    python_node = parent.createNode("python", node_name="set_usd_attr_auto")
+    # Create a Python LOP to set the attribute ("pythonscript" is the
+    # LOP type name; "python" does not exist in the Lop category)
+    python_node = parent.createNode("pythonscript", node_name="set_usd_attr_auto")
     python_node.setInput(0, node)
 
     # Build the Python snippet
@@ -642,14 +643,21 @@ def _get_usd_composition(
 
     prim_index = prim.GetPrimIndex()
 
+    # Pcp.PrimIndex has no nodeRange in current USD builds; walk the
+    # composition graph from rootNode instead.
+    def _walk_nodes(node):
+        yield node
+        for child in node.children:
+            yield from _walk_nodes(child)
+
     arcs: list[dict[str, Any]] = []
     if prim_index.IsValid():
-        for node in prim_index.nodeRange:
+        for node in _walk_nodes(prim_index.rootNode):
             arc_info: dict[str, Any] = {
                 "arc_type": str(node.arcType),
                 "layer": str(node.layerStack.identifier.rootLayer)
                          if node.layerStack else None,
-                "path": str(node.path),
+                "path": str(getattr(node, "path", "")),
                 "has_specs": node.hasSpecs,
             }
             arcs.append(arc_info)

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/rendering_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/rendering_handlers.py
@@ -455,9 +455,10 @@ def start_render(
             start = float(frame_range[0])
             end = float(frame_range[1])
             inc = float(frame_range[2]) if len(frame_range) > 2 else 1.0
+            # RopNode.render takes the increment as the third element of
+            # frame_range; there is no frame_increment keyword.
             node.render(
-                frame_range=(start, end),
-                frame_increment=inc,
+                frame_range=(start, end, inc),
                 output_progress=True,
             )
         else:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/viewport_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/viewport_handlers.py
@@ -765,7 +765,12 @@ def log_status(message: str, severity: str = "message") -> dict:
         "error": hou.severityType.Error,
     }
     sev = severity_map.get(severity.lower(), hou.severityType.Message)
-    hou.ui.setStatusMessage(message, severity=sev)
+    if hou.isUIAvailable():
+        hou.ui.setStatusMessage(message, severity=sev)
+    else:
+        # Headless sessions (hython/hbatch) have no status bar; stay a
+        # harmless no-op so instruction-following clients never error.
+        print(f"[status] {message}")
     return {"message": message, "severity": severity}
 
 

--- a/python/fxhoudinimcp/prompts/markdown/server_instructions.md
+++ b/python/fxhoudinimcp/prompts/markdown/server_instructions.md
@@ -21,24 +21,24 @@ The lists below are search hints, not exhaustive. Always call `list_node_types(c
 
 ### SOPs (context='Sop')
 
-*   Camera/projection: camerafrust, ray, project, uvproject, uvtexture
-*   Volumes/VDB: filter='vdb' — vdbfrompolygons, convertvdb, vdbcombine, vdbsmooth, vdbreshape, vdbmorph, vdbadvectpoints, etc. Also: isooffset, pointsfromvolume, volumewrangle
+*   Camera/projection: ray, project, uvproject, texture
+*   Volumes/VDB: filter='vdb' — vdbfrompolygons, convertvdb, vdbcombine, vdbsmooth, vdbreshapesdf, vdbmorphsdf, vdbadvectpoints, etc. Also: isooffset, pointsfromvolume, volumewrangle
 *   Attributes: filter='attrib' — attribtransfer, attribpromote, attribreorient, attribinterpolate, attribfrommap, attribexpression, attribnoise, attribfromvolume, etc.
 *   Deformers: mountain, ripple, twist, bend, lattice, pathdeform, pointdeform, deltamush, shrinkwrap, creep, surfacedeform, inflate, deflate, bulge, wrinkledeformer
 *   UVs: filter='uv' — uvautoseam, uvflatten, uvlayout, uvtransform, uvproject, uvunwrap
 *   Topology: boolean, booleanfracture, polyextrude, polybridge, polysplit, polyfill, polydoctor, polyreduce, remesh, fuse, join, clean, divide, triangulate2d
-*   Groups: filter='group' — groupcreate, groupcombine, grouppromote, groupexpression, groupbyborders, groupbyrange
-*   Terrain: filter='heightfield' — heightfield\_noise, heightfield\_erode, heightfield\_scatter, heightfield\_maskby\*, heightfield\_blur, heightfield\_project, heightfield\_tile, heightfield\_terrace, etc.
-*   KineFX/rigging: rigpose, rigsolver, fullbodyik, skeletonblend, bonecapturebiharmonic, bonedeform, orientalongcurve
+*   Groups: filter='group' — groupcreate, groupcombine, grouppromote, groupexpression, grouprange
+*   Terrain: filter='heightfield' — heightfield\_noise, heightfield\_erode, heightfield\_scatter, heightfield\_maskby\*, heightfield\_blur, heightfield\_project, heightfield\_tilesplit, heightfield\_terrace, etc.
+*   KineFX/rigging: filter='kinefx' — kinefx::rigpose, kinefx::fullbodyik, kinefx::skeletonblend, bonecapturebiharmonic, bonedeform, orientalongcurve
 *   APEX rigging: filter='apex' — apex::packcharacter, apex::configurecharacter, apex::graph, apex::buildfkgraph, etc.
 *   Curves: resample, sweep, polywire, revolve, fillet, ends, carve, convertline, surfsect
-*   Scatter/points: scatter, scatteralign, pointgenerate, pointjitter, pointrelax, pointreplicate, pointvelocity
+*   Scatter/points: scatter, scatteralign, pointgenerate, pointjitter, relax, pointreplicate, pointvelocity
 *   Copy/instance: copytopoints, copytocurves, copyxform, pack, unpack, repack, assemble
 *   Fracture: voronoifracture, booleanfracture, rbdmaterialfracture, rbdinteriordetail, rbdconfigure
 *   SOP-level solvers: filter='pyro'|'vellum'|'flip'|'mpm'|'whitewater'|'ripple'|'shallowwater' — each has solver+source+postprocess nodes at SOP level
 *   Ocean: filter='ocean' — oceanspectrum, oceanevaluate, oceanfoam, oceansource
-*   Hair/groom: filter='hair'|'guide' — hairgenerate, hairclump, haircardgen, guideprocess, guidegroom, guideadvect
-*   Feather: filter='feather' — featherprimitive, feathernoise, feathersurface, feathertemplate
+*   Hair/groom: filter='hair'|'guide' — hairgen, hairclump, haircardgen, guideprocess, guidegroom, guideadvect
+*   Feather: filter='feather' — featherprimitive, feathernoise, feathersurface
 *   Clouds: cloudnoise, cloudshapegenerate, cloudbillowynoise
 *   Distance: findshortestpath, distancealonggeometry, distancefromgeometry
 *   Agents/Crowds: filter='agent'|'crowd' — agent, agentclip, agentlayer, agentprep, crowdsource, crowdassignlayers
@@ -53,11 +53,11 @@ The lists below are search hints, not exhaustive. Always call `list_node_types(c
 
 ### LOPs (context='Lop')
 
-*   Scene assembly: sublayer, reference, payload, componentoutput, stagemanager, sceneimport
-*   SOP bridge: sopimport, sopcreate, sopmodify, sopcrowdimport, sopcharacterimport
+*   Scene assembly: sublayer, reference (handles payloads), componentoutput, stagemanager, sceneimport
+*   SOP bridge: sopimport, sopcreate, sopmodify, sopcrowdimport, kinefx::sopcharacterimport
 *   Transforms: xform, edit, matchsize, restructurescenegraph, duplicate
 *   Rendering: filter='karma'|'render' — karmarendersettings, renderproduct, rendervar, karmastandardrendervars
-*   Karma effects: karmaphysicalsky, karmaskyatmosphere, karmafogbox, karmatexturebaker, karmacryptomatte, karmashadowcatcher, backgroundplate
+*   Karma effects: karmaphysicalsky, karmaskyatmosphere, karmafogbox, karmatexturebaker, karmacryptomatte, backgroundplate
 *   Materials: materiallibrary, assignmaterial, editmaterialproperties, materialvariation, materiallinker
 *   Lights: light, distantlight, domelight, lightmixer, portallight, geometrylight, lightlinker, lpetag
 *   Instancing: instancer, modifypointinstances, splitpointinstancers, extractinstances
@@ -72,36 +72,35 @@ The lists below are search hints, not exhaustive. Always call `list_node_types(c
 
 *   Pyro/smoke: filter='pyro'|'smoke' — pyrosolver, pyrosolver\_sparse, smokesolver, smokeobject
 *   FLIP: flipsolver, flipobject, flipconfigureobject
-*   RBD: filter='rbd'|'bullet' — rbdobject, rbdpackedobject, rbdsolver, bulletdata, bulletsolver, rbdautofreeze
+*   RBD: filter='rbd'|'bullet' — rbdobject, rbdpackedobject, rbdsolver, bulletdata, bulletrbdsolver, rbdautofreeze
 *   Vellum: filter='vellum' — vellumsolver, vellumobject, vellumsource, vellumconstraints, vellumrestblend
-*   Cloth: clothobject, clothsolver, clothmaterial
+*   Cloth: clothobject, clothsolver, clothconfigureobject
 *   Wire: wireobject, wiresolver, wirephysparms
 *   FEM: femsolidobject, femsolver, femhybridobject
 *   Whitewater: whitewaterobject, whitewatersolver
 *   POP forces: filter='pop' — popforce, popdrag, popwind, popattract, popcurveforce, popflock, popgrains, popfloatbyvolumes
 *   POP steering: popsteeralign, popsteeravoid, popsteercohesion, popsteerseek, popsteerobstacle, popsteerpath
-*   POP utility: popsource, popkill, popreplicate, popspeedlimit, popcolor, popinstance, popgroup, popproperties
+*   POP utility: popsource, popkill, popreplicate, popspeedlimit, popcolor, popinstance, popgroup, popproperty
 *   Crowd: filter='crowd'|'agent' — crowdobject, crowdsolver, crowdstate, crowdtransition, crowdtrigger
-*   Forces: gravity, uniformforce, drag, windforce, vortexforce, fanforce, buoyancyforce, magnetforce, fieldforce
-*   RBD constraints: constraintnetwork, conetwistconstraint, rbdhingeconstraint, rbdpinconstraint, rbdspringconstraint
+*   Forces: gravity, uniformforce, drag, windforce, vortexforce, buoyancyforce, magnetforce, fieldforce
+*   RBD constraints: constraintnetwork, conetwistconrel, rbdhingeconstraint, rbdpinconstraint, rbdspringconstraint
 *   Collision: staticobject, groundplane, terrainobject
 *   Microsolvers: filter='gas' — gasturbulence, gasdisturb, gasshred, gasbuoyancy, gasvortexconfinement, gasadvect, gasresizefield, gasdissipate, gasburn, gasprojectnondivergent, etc.
 *   Anchors: filter='anchor' — anchorobjpointidpos, anchorobjpointnumpos, anchorobjspacepos, etc.
 
 ### COPs (prefer Copernicus context='Cop'; COP2 context='Cop2' is deprecated since H20.5)
 
-*   Color: colorcorrect, colorcurve, hsv, gamma, bright, contrast, levels, invert, tonemap
-*   Keying: chromakey, lumakey, lumamatte, cryptomatte, dilateerode
-*   Filters: blur, sharpen, median, defocus, edge, emboss, grain, denoise, denoiseai
-*   Compositing: over, under, atop, inside, outside, composite, layer, add, subtract, multiply, screen, zcomp
-*   Transforms: transform, crop, scale, flip, cornerpin, deform, tile, distort
-*   Generators: color, noise, font, shape, ramp, rotoshape, colorwheel, constant, checkerboard
-*   Channels: channelcopy, merge, premultiply, switchalpha, channelextract, channeljoin
+*   Color: colorcorrect, hsv, gamma, bright, contrast, invert, tonemap
+*   Keying: chromakey, cryptomatte, dilateerode
+*   Filters: blur, sharpen, median, defocus, edgedetect, denoisetvd, denoiseai
+*   Compositing: blend, layer, zcomp
+*   Transforms: xform, crop, flip, cornerpin, latticedeform, tilepattern, distort
+*   Generators: font, ramp, constant, checkerboard
+*   Channels: channelextract, channeljoin, channelsplit, channelswap, premult, switch
 *   Copernicus noise: fractalnoise, worleynoise, crystalnoise, phasornoise, bubblenoise
 *   Copernicus 3D: rasterizegeo, rasterizecurves, rasterizevolume, raytrace, bakegeometrytextures, triplanar
 *   Copernicus height/SDF: heighttonormal, heighttoambientocclusion, sdfshape, sdfblend, monotosdf
 *   Copernicus pyro: pyro\_configure, pyro\_advect, pyro\_buoyancy, pyro\_turbulence, pyro\_dissipate
-*   Copernicus grunge: grunge\_rust, grunge\_aurora, grunge\_pinebark, grunge\_layerednoise
 
 ### CHOPs (context='Chop')
 
@@ -109,9 +108,9 @@ The lists below are search hints, not exhaustive. Always call `list_node_types(c
 *   Math: math, function, logic, count, slope, area, envelope, vector
 *   Constraints: filter='constraint' — constraintblend, constraintlookat, constraintobject, constraintpath, constraintparent, etc.
 *   KineFX: inversekin, iksolver, extractbonetransforms, extractlocomotion, footplant
-*   Timing: shift, stretch, trim, cycle, extend, warp, dynamicwarp, timerange, resample, speed
-*   Audio: audioin, oscillator, spectrum, pitch, voicesplit, phoneme, passfilter
-*   Data: channel, constant, file, fetch, stash, record, copy, merge, blend, interpolate
+*   Timing: shift, stretch, trim, cycle, extend, warp, dynamicwarp, timerange, resample
+*   Audio: audioin, oscillator, spectrum, pitch, voicesplit, phoneme
+*   Data: channel, constant, file, fetch, stash, record, copy, merge, blend, interp
 
 ### TOPs (context='Top')
 

--- a/python/fxhoudinimcp/resources/scene_resources.py
+++ b/python/fxhoudinimcp/resources/scene_resources.py
@@ -27,9 +27,9 @@ async def node_info(path: str, ctx: Context) -> dict:
 
 @mcp.resource("houdini://scene/tree")
 async def scene_tree(ctx: Context) -> dict:
-    """Complete node tree of the current scene."""
+    """Top-level node tree of the current scene."""
     bridge = _get_bridge(ctx)
-    return await bridge.execute("scene.get_context_info", {"context": "all"})
+    return await bridge.execute("scene.get_context_info", {"context": "/"})
 
 
 @mcp.resource("houdini://errors")

--- a/tests/integration/bridge_e2e.py
+++ b/tests/integration/bridge_e2e.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""End-to-end transport test: real hwebserver in hython, real HoudiniBridge.
+
+    python tests/integration/bridge_e2e.py
+
+Spawns one hython process that runs the actual in-Houdini server
+(fxhoudinimcp_server.startup), then drives it over HTTP with the MCP
+server's own async HoudiniBridge — the exact production path. Exercises
+success envelopes, structured errors, and scene mutation round-trips.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import asyncio
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "python"))
+sys.path.insert(0, str(REPO_ROOT / "tests"))
+
+from run_integration import find_hython  # noqa: E402
+
+_SERVER_SNIPPET = """
+import sys
+sys.path.insert(0, {scripts!r})
+import fxhoudinimcp_server.startup as startup
+startup.start()  # blocks in hython, serving requests
+import time
+time.sleep(3600)
+"""
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+async def _exercise(port: int) -> None:
+    from fxhoudinimcp.bridge import HoudiniBridge
+    from fxhoudinimcp.errors import FXHoudiniError
+
+    bridge = HoudiniBridge(host="127.0.0.1", port=port)
+    try:
+        health = await bridge.health_check()
+        assert health.get("status") == "ok", health
+        print(f"[e2e] health: Houdini {health.get('houdini_version')}")
+
+        info = await bridge.execute("scene.get_scene_info")
+        assert "houdini_version" in str(info), info
+        print("[e2e] scene.get_scene_info over HTTP: ok")
+
+        created = await bridge.execute(
+            "nodes.create_node",
+            {"parent_path": "/obj", "node_type": "geo", "name": "via_http"},
+        )
+        assert created["node_path"] == "/obj/via_http", created
+        listed = await bridge.execute(
+            "nodes.find_nodes", {"pattern": "via_http"}
+        )
+        assert listed["count"] == 1, listed
+        print("[e2e] node created and found through the bridge: ok")
+
+        big = await bridge.execute(
+            "nodes.list_node_types", {"context": "Sop", "limit": 5000}
+        )
+        assert big["total_count"] > 200
+        print(f"[e2e] large payload ({big['total_count']} types) serialized: ok")
+
+        try:
+            await bridge.execute("nodes.create_node", {
+                "parent_path": "/obj", "node_type": "not_a_real_type",
+            })
+        except FXHoudiniError as exc:
+            assert "not_a_real_type" in str(exc), exc
+            print("[e2e] structured error surfaced through the bridge: ok")
+        else:
+            raise AssertionError("bad node type did not raise through bridge")
+
+        try:
+            await bridge.execute("no.such.command")
+        except FXHoudiniError as exc:
+            print(f"[e2e] unknown command rejected: ok ({type(exc).__name__})")
+        else:
+            raise AssertionError("unknown command did not raise")
+    finally:
+        await bridge.close()
+
+
+def main() -> int:
+    hython = find_hython()
+    port = _free_port()
+    scripts = str(REPO_ROOT / "houdini" / "scripts" / "python")
+
+    env = os.environ.copy()
+    env["FXHOUDINIMCP_PORT"] = str(port)
+    server = subprocess.Popen(
+        [str(hython), "-c", _SERVER_SNIPPET.format(scripts=scripts)],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    print(f"[e2e] hython server starting on port {port} (pid {server.pid})")
+
+    try:
+        # Wait for the server to answer before testing. Any HTTP status
+        # (even 4xx for a GET on the POST-only endpoint) means it is up.
+        import urllib.error
+        import urllib.request
+
+        deadline = time.time() + 120
+        while True:
+            if server.poll() is not None:
+                output = server.stdout.read() if server.stdout else ""
+                raise RuntimeError(f"server exited early:\n{output}")
+            if time.time() >= deadline:
+                raise RuntimeError("server never became reachable")
+            try:
+                urllib.request.urlopen(
+                    f"http://127.0.0.1:{port}/api", timeout=0.5
+                )
+                break
+            except urllib.error.HTTPError:
+                break
+            except Exception:
+                time.sleep(0.5)
+
+        asyncio.run(_exercise(port))
+        print("[e2e] ALL TRANSPORT CHECKS PASSED")
+        return 0
+    finally:
+        server.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,6 +46,10 @@ else:
 # (command, milliseconds) for every dispatched call, across the session.
 _OP_TIMINGS: list[tuple[str, float]] = []
 
+# Smoke-mode (allow_error) calls that actually failed: their success path
+# is still unverified. Reported in the session summary.
+_SMOKE_ERRORS: dict[str, str] = {}
+
 
 @pytest.fixture(autouse=True)
 def fresh_scene():
@@ -80,6 +84,9 @@ def call():
                 assert error.get("code") != "UNKNOWN_COMMAND", error
                 assert str(error.get("message", "")).strip(), (
                     f"{_command} failed with an empty error message: {error}"
+                )
+                _SMOKE_ERRORS.setdefault(
+                    _command, str(error.get("message", ""))[:70]
                 )
             return result
         if expect_error:
@@ -125,3 +132,9 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         terminalreporter.write_line("never called this session:")
         for command in untested:
             terminalreporter.write_line(f"  {command}")
+    if _SMOKE_ERRORS:
+        terminalreporter.write_line(
+            "smoke-mode calls that errored (success path unverified):"
+        )
+        for command, message in sorted(_SMOKE_ERRORS.items()):
+            terminalreporter.write_line(f"  {command}: {message}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -62,16 +62,33 @@ def call():
     asserts the command failed and returns the error dict instead.
     """
 
-    def _call(command: str, expect_error: bool = False, **params):
-        result = dispatcher.dispatch(command, params)
-        _OP_TIMINGS.append((command, result.get("timing_ms", 0.0)))
+    # Leading underscores on the bound arguments keep them from colliding
+    # with handler parameters of the same name (e.g. execute_hscript's
+    # "command"), which arrive via **params.
+    def _call(
+        _command: str,
+        expect_error: bool = False,
+        allow_error: bool = False,
+        **params,
+    ):
+        result = dispatcher.dispatch(_command, params)
+        _OP_TIMINGS.append((_command, result.get("timing_ms", 0.0)))
+        if allow_error:
+            # Smoke mode: success or a CLEAN structured error both pass.
+            if result["status"] == "error":
+                error = result["error"]
+                assert error.get("code") != "UNKNOWN_COMMAND", error
+                assert str(error.get("message", "")).strip(), (
+                    f"{_command} failed with an empty error message: {error}"
+                )
+            return result
         if expect_error:
             assert result["status"] == "error", (
-                f"{command} unexpectedly succeeded: {result.get('data')}"
+                f"{_command} unexpectedly succeeded: {result.get('data')}"
             )
             return result["error"]
         assert result["status"] == "success", (
-            f"{command} failed: {result.get('error', {}).get('message')}"
+            f"{_command} failed: {result.get('error', {}).get('message')}"
         )
         return result["data"]
 
@@ -79,7 +96,7 @@ def call():
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
-    """Print per-command timing aggregates after the run."""
+    """Print per-command timing aggregates and session command coverage."""
     if not _OP_TIMINGS:
         return
     stats: dict[str, list[float]] = defaultdict(list)
@@ -97,3 +114,14 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         terminalreporter.write_line(
             f"{command:<42} {count:>5} {mean:>9.1f} {mx:>9.1f}"
         )
+
+    registered = set(dispatcher.list_commands())
+    called = set(stats)
+    untested = sorted(registered - called)
+    terminalreporter.write_sep(
+        "=", f"command coverage: {len(called & registered)}/{len(registered)}"
+    )
+    if untested:
+        terminalreporter.write_line("never called this session:")
+        for command in untested:
+            terminalreporter.write_line(f"  {command}")

--- a/tests/integration/test_authoring_scenarios_live.py
+++ b/tests/integration/test_authoring_scenarios_live.py
@@ -1,0 +1,240 @@
+"""Deep authoring scenarios: HDA packaging, Solaris scene assembly,
+MaterialX lookdev, and USD lighting — every claim checked on the stage.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import os
+
+# Third-party
+import hou
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestHdaAuthoringScenario:
+    """User: 'Package this setup into a reusable asset and use it again.'"""
+
+    def test_create_hda_and_reinstance_it(self, call, tmp_path):
+        subnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="subnet", name="rock"
+        )["node_path"]
+        call("nodes.create_node", parent_path=subnet, node_type="geo", name="inner")
+
+        hda_file = str(tmp_path / "rock_asset.hda").replace("\\", "/")
+        created = call(
+            "hda.create_hda",
+            node_path=subnet,
+            hda_file=hda_file,
+            type_name="audit::rock_asset",
+            label="Rock Asset",
+        )
+        assert os.path.isfile(hda_file), "create_hda claimed success, wrote no file"
+        flat = str(created)
+        assert "rock_asset" in flat, created
+
+        # The user outcome: the new type is instantiable like any built-in.
+        instance = call(
+            "nodes.create_node",
+            parent_path="/obj",
+            node_type="audit::rock_asset",
+            name="rock_copy",
+        )
+        node = hou.node(instance["node_path"])
+        assert node is not None
+        assert node.type().definition() is not None, "instance is not an HDA"
+        assert node.type().definition().libraryFilePath() == hda_file
+
+        info = call("hda.get_hda_info", node_path=instance["node_path"])
+        assert "Rock Asset" in str(info)
+        sections = call("hda.get_hda_sections", node_path=instance["node_path"])
+        assert sections, sections
+
+
+class TestSolarisSceneScenario:
+    """User: 'Build a USD scene: import my SOP asset, shade it with
+    MaterialX, light it, add a camera, and set up Karma.'"""
+
+    def test_full_usd_scene_assembly(self, call):
+        # SOP asset to bring in
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="hero"
+        )["node_path"]
+        call("nodes.create_node", parent_path=geo, node_type="testgeometry_pighead")
+
+        lopnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="lopnet", name="assembly"
+        )["node_path"]
+
+        # 1. Import the SOP geometry onto the stage. The import root is
+        # the pathprefix parm (primpath is unrelated on sopimport).
+        imported = call(
+            "lops.create_lop_node",
+            parent_path=lopnet,
+            lop_type="sopimport",
+            name="hero_import",
+        )["node_path"]
+        call(
+            "parameters.set_parameters",
+            node_path=imported,
+            params={
+                "soppath": geo,
+                "enable_pathprefix": True,
+                "pathprefix": "/geo/hero",
+            },
+        )
+
+        # 2. MaterialX material in a material library
+        matlib = call(
+            "lops.create_lop_node",
+            parent_path=lopnet,
+            lop_type="materiallibrary",
+            name="mats",
+        )["node_path"]
+        call("nodes.connect_nodes", source_path=imported, dest_path=matlib)
+        call(
+            "parameters.set_parameter",
+            node_path=matlib,
+            parm_name="matpathprefix",
+            value="/materials/",
+        )
+        shader = call(
+            "nodes.create_node",
+            parent_path=matlib,
+            node_type="mtlxstandard_surface",
+            name="clay",
+        )["node_path"]
+        call(
+            "parameters.set_parameters",
+            node_path=shader,
+            params={"base_colorr": 0.6, "base_colorg": 0.3, "base_colorb": 0.2},
+        )
+
+        # 3. Bind the material to the hero prim
+        assign = call(
+            "lops.create_lop_node",
+            parent_path=lopnet,
+            lop_type="assignmaterial",
+            name="bind",
+        )["node_path"]
+        call("nodes.connect_nodes", source_path=matlib, dest_path=assign)
+        call(
+            "parameters.set_parameters",
+            node_path=assign,
+            params={"primpattern1": "/geo/hero", "matspecpath1": "/materials/clay"},
+        )
+
+        # 4. Lights and camera
+        light = call(
+            "lops.create_light", parent_path=lopnet, light_type="dome", intensity=2.5
+        )
+        light_node = light["node_path"]
+        call("nodes.connect_nodes", source_path=assign, dest_path=light_node)
+        camera = call(
+            "lops.create_lop_node",
+            parent_path=lopnet,
+            lop_type="camera",
+            name="render_cam",
+            prim_path="/cameras/render_cam",
+        )["node_path"]
+        call("nodes.connect_nodes", source_path=light_node, dest_path=camera)
+
+        # 5. Karma render settings as the stage output
+        settings = call(
+            "lops.create_lop_node",
+            parent_path=lopnet,
+            lop_type="karmarendersettings",
+            name="karma",
+        )["node_path"]
+        call("nodes.connect_nodes", source_path=camera, dest_path=settings)
+        call("nodes.set_node_flags", node_path=settings, display=True)
+
+        # The user outcome: ONE stage containing everything.
+        prims = str(call("lops.list_usd_prims", node_path=settings))
+        for expected in ("/geo/hero", "/materials/clay", "/cameras/render_cam"):
+            assert expected in prims, f"{expected} missing from final stage"
+
+        materials = call("lops.get_usd_materials", node_path=settings)
+        assert "clay" in str(materials)
+
+        hero = call(
+            "lops.get_usd_prim", node_path=settings, prim_path="/geo/hero"
+        )
+        assert hero, hero
+
+        # The dome light exists with the intensity actually applied.
+        light_prim_path = light.get("prim_path") or "/lights/" + light_node.split("/")[-1]
+        intensity = call(
+            "lops.get_usd_attribute",
+            node_path=settings,
+            prim_path=light_prim_path,
+            attr_name="inputs:intensity",
+        )
+        assert "2.5" in str(intensity), (
+            f"create_light claimed intensity=2.5 but stage says: {intensity}"
+        )
+
+        stats = call("lops.get_usd_prim_stats", node_path=settings)
+        assert stats, stats
+
+
+class TestLightRigScenario:
+    """User: 'Give me a three-point light rig.'"""
+
+    def test_rig_lights_are_chained_and_configured(self, call):
+        lopnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="lopnet", name="rig"
+        )["node_path"]
+        rig = call(
+            "lops.create_light_rig",
+            parent_path=lopnet,
+            preset="three_point",
+            intensity_mult=2.0,
+        )
+        created = rig.get("created_nodes", rig.get("nodes", rig.get("all_nodes")))
+        assert created and len(created) == 3, rig
+
+        # All three lights must be on the LAST node's stage (chained).
+        last = created[-1]
+        lights = call("lops.list_lights", node_path=last)
+        flat = str(lights)
+        for name in ("key_light", "fill_light", "rim_light"):
+            assert name in flat, f"{name} missing from rig output stage: {flat}"
+
+        # Intensity multiplier must actually land on the USD prims.
+        key = call(
+            "lops.get_usd_attribute",
+            node_path=last,
+            prim_path="/lights/key_light",
+            attr_name="inputs:intensity",
+        )
+        assert "2" in str(key.get("value", key)), (
+            f"key light intensity (1.0 * mult 2.0) not applied: {key}"
+        )
+
+
+class TestMaterialXLookdevScenario:
+    """User: 'Make me a MaterialX clay shader.' — the materialx branch of
+    create_material sets parms through _set_parm_safe, which silently
+    swallows failures, so verify every claimed value on the shader."""
+
+    def test_materialx_params_really_applied(self, call):
+        data = call(
+            "workflow.create_material",
+            name="mtlx_clay",
+            mat_type="materialx",
+            base_color=[0.2, 0.3, 0.4],
+            roughness=0.6,
+            metallic=1.0,
+        )
+        shader = hou.node(data["material_path"])
+        assert shader is not None
+        assert shader.type().name().startswith("mtlx"), shader.type().name()
+        base = [shader.parm(f"base_color{c}").eval() for c in "rgb"]
+        assert base == pytest.approx([0.2, 0.3, 0.4]), (
+            f"base_color claimed applied but shader has {base}"
+        )
+        assert shader.parm("specular_roughness").eval() == pytest.approx(0.6)
+        assert shader.parm("metalness").eval() == pytest.approx(1.0)

--- a/tests/integration/test_command_coverage_live.py
+++ b/tests/integration/test_command_coverage_live.py
@@ -67,7 +67,11 @@ class TestTops:
         assert "5" in str(states) or "workitems" in str(states).lower(), states
         call("tops.get_work_item_info", node_path=path, work_item_index=0, allow_error=True)
         call("tops.get_pdg_graph", node_path=topnet, allow_error=True)
-        call("tops.cook_top_node", node_path=path, block=True, allow_error=True)
+        call("tops.cook_top_node", node_path=path, block=True)
+        cooked = call("tops.get_work_item_states", node_path=path)
+        assert "Cooked" in str(cooked) or "success" in str(cooked).lower(), (
+            f"PDG cook claimed done but no cooked work items: {cooked}"
+        )
         call("tops.get_top_scheduler_info", node_path=topnet, allow_error=True)
         call("tops.dirty_work_items", node_path=path)
         call("tops.pause_top_cook", node_path=topnet, allow_error=True)
@@ -465,14 +469,22 @@ class TestLopsModule:
         lights = call("lops.list_lights", node_path=light_node)
         assert lights, lights
         prim_path = light.get("prim_path")
-        if prim_path:
-            call(
-                "lops.set_light_properties",
-                node_path=light_node,
-                prim_path=prim_path,
-                properties={"intensity": 5.0},
-                allow_error=True,
-            )
+        assert prim_path, light
+        updated = call(
+            "lops.set_light_properties",
+            node_path=light_node,
+            prim_path=prim_path,
+            properties={"intensity": 5.0},
+        )
+        intensity = call(
+            "lops.get_usd_attribute",
+            node_path=updated["python_node"],
+            prim_path=prim_path,
+            attr_name="inputs:intensity",
+        )
+        assert "5" in str(intensity.get("value", intensity)), (
+            f"set_light_properties claimed intensity=5.0 but stage says {intensity}"
+        )
 
 
 class TestMopUp:
@@ -573,24 +585,19 @@ class TestMopUp:
             "nodes.create_node", parent_path="/obj", node_type="geo", name="src"
         )["node_path"]
         sphere = call("nodes.create_node", parent_path=geo, node_type="sphere")
-        flip = call(
-            "workflow.setup_flip_sim",
-            source_geo=sphere["node_path"],
-            allow_error=True,
-        )
-        if flip["status"] == "success":
-            for path in flip["data"].get("all_nodes", []):
-                assert hou.node(path) is not None, f"claimed node missing: {path}"
+        flip = call("workflow.setup_flip_sim", source_geo=sphere["node_path"])
+        assert flip["success"] is True
+        for path in flip.get("all_nodes", []):
+            assert hou.node(path) is not None, f"claimed node missing: {path}"
+
         cloth_geo = call(
             "nodes.create_node", parent_path="/obj", node_type="geo", name="cloth"
         )["node_path"]
         call("nodes.create_node", parent_path=cloth_geo, node_type="grid")
-        vellum = call(
-            "workflow.setup_vellum_sim", geo_path=cloth_geo, allow_error=True
-        )
-        if vellum["status"] == "success":
-            for path in vellum["data"].get("all_nodes", []):
-                assert hou.node(path) is not None, f"claimed node missing: {path}"
+        vellum = call("workflow.setup_vellum_sim", geo_path=cloth_geo)
+        assert vellum["success"] is True
+        for path in vellum.get("all_nodes", []):
+            assert hou.node(path) is not None, f"claimed node missing: {path}"
 
 
 class TestAnimationModule:

--- a/tests/integration/test_command_coverage_live.py
+++ b/tests/integration/test_command_coverage_live.py
@@ -1,0 +1,616 @@
+"""Coverage sweep over the command categories no other test exercises.
+
+Strong assertions where the outcome is cheap to verify against the live
+scene; smoke assertions (success OR a clean structured error — never an
+unknown command or an empty message) for UI-dependent or environment-
+dependent commands. The session summary in conftest reports which of the
+registered commands were never called.
+"""
+
+from __future__ import annotations
+
+# Third-party
+import hou
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestDops:
+    @pytest.fixture
+    def dopnet(self, call) -> str:
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="dopnet", name="sim"
+        )["node_path"]
+        # The DOP object only enters the simulation when it is displayed.
+        hou.node(geo).createNode("emptyobject", "thing").setDisplayFlag(True)
+        return geo
+
+    def test_dop_lifecycle(self, call, dopnet):
+        call("dops.step_simulation", node_path=dopnet, steps=2)
+        info = call("dops.get_simulation_info", node_path=dopnet)
+        assert str(info), info
+        objects = call("dops.list_dop_objects", node_path=dopnet)
+        names = [o["name"] if isinstance(o, dict) else o for o in objects["objects"]]
+        assert names, f"no DOP objects after stepping: {objects}"
+        call(
+            "dops.get_dop_object",
+            node_path=dopnet,
+            object_name=names[0],
+            allow_error=True,
+        )
+        call("dops.get_dop_relationships", node_path=dopnet)
+        call("dops.get_sim_memory_usage", node_path=dopnet)
+        call("dops.reset_simulation", node_path=dopnet)
+        call(
+            "dops.get_dop_field",
+            node_path=dopnet,
+            object_name="thing",
+            data_path="Geometry",
+            field_name="vel",
+            allow_error=True,
+        )
+
+
+class TestTops:
+    def test_top_cook_lifecycle(self, call):
+        topnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="topnet", name="pdg"
+        )["node_path"]
+        gen = hou.node(topnet).createNode("genericgenerator")
+        gen.parm("itemcount").set(5)
+        path = gen.path()
+
+        call("tops.get_top_network_info", node_path=topnet, allow_error=True)
+        call("tops.generate_static_items", node_path=path)
+        states = call("tops.get_work_item_states", node_path=path)
+        assert "5" in str(states) or "workitems" in str(states).lower(), states
+        call("tops.get_work_item_info", node_path=path, work_item_index=0, allow_error=True)
+        call("tops.get_pdg_graph", node_path=topnet, allow_error=True)
+        call("tops.cook_top_node", node_path=path, block=True, allow_error=True)
+        call("tops.get_top_scheduler_info", node_path=topnet, allow_error=True)
+        call("tops.dirty_work_items", node_path=path)
+        call("tops.pause_top_cook", node_path=topnet, allow_error=True)
+        call("tops.cancel_top_cook", node_path=topnet, allow_error=True)
+
+
+class TestCops:
+    def test_cop_create_and_inspect(self, call):
+        copnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="copnet", name="comp"
+        )["node_path"]
+        types = call("cops.list_cop_node_types", filter="fractalnoise")
+        names = [t["name"] for t in types["cop_types"]]
+        assert "fractalnoise" in names, (
+            f"list_cop_node_types does not surface Copernicus types: {names}"
+        )
+        created = call(
+            "cops.create_cop_node",
+            parent_path=copnet,
+            cop_type="fractalnoise",
+            allow_error=True,
+        )
+        if created["status"] == "success":
+            cop_path = created["data"]["node_path"]
+            call("cops.get_cop_info", node_path=cop_path, allow_error=True)
+            call("cops.set_cop_flags", node_path=cop_path, display=True, allow_error=True)
+            call("cops.get_cop_layer", node_path=cop_path, allow_error=True)
+            call("cops.get_cop_geometry", node_path=cop_path, allow_error=True)
+            call("cops.get_cop_vdb", node_path=cop_path, allow_error=True)
+
+
+class TestChops:
+    def test_chop_data_and_export(self, call):
+        chopnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="chopnet", name="motion"
+        )["node_path"]
+        wave = call(
+            "chops.create_chop_node", parent_path=chopnet, chop_type="wave"
+        )
+        wave_path = wave["node_path"]
+        channels = call("chops.list_chop_channels", node_path=wave_path)
+        assert channels.get("channels"), channels
+        channel = channels["channels"][0]
+        channel_name = channel["name"] if isinstance(channel, dict) else channel
+        data = call(
+            "chops.get_chop_data",
+            node_path=wave_path,
+            channel_name=channel_name,
+            start=0,
+            end=10,
+        )
+        assert str(data), data
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="target"
+        )["node_path"]
+        call(
+            "chops.export_chop_to_parm",
+            chop_path=wave_path,
+            channel_name=channel_name,
+            target_node_path=geo,
+            target_parm_name="tx",
+            allow_error=True,
+        )
+
+
+class TestTakes:
+    def test_take_roundtrip(self, call):
+        call("takes.create_take", name="lighting_v2")
+        call("takes.set_current_take", name="lighting_v2")
+        current = call("takes.get_current_take")
+        assert "lighting_v2" in str(current)
+        takes = call("takes.list_takes")
+        assert "lighting_v2" in str(takes)
+        call("takes.set_current_take", name="Main", allow_error=True)
+
+
+class TestHda:
+    def test_hda_create_inspect_roundtrip(self, call, tmp_path):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="subnet", name="asset"
+        )["node_path"]
+        hda_file = str(tmp_path / "test_asset.hda").replace("\\", "/")
+        created = call(
+            "hda.create_hda",
+            node_path=geo,
+            hda_file=hda_file,
+            type_name="test::asset",
+            label="Test Asset",
+            allow_error=True,
+        )
+        if created["status"] != "success":
+            pytest.skip(f"create_hda not available here: {created['error']['message']}")
+        import os
+
+        assert os.path.isfile(hda_file), "create_hda claimed success, wrote no file"
+        node_path = created["data"].get("node_path", geo)
+        call("hda.get_hda_info", node_path=node_path, allow_error=True)
+        sections = call("hda.get_hda_sections", node_path=node_path, allow_error=True)
+        if sections["status"] == "success":
+            listed = sections["data"].get("sections", [])
+            name = listed[0]["name"] if listed and isinstance(listed[0], dict) else (
+                listed[0] if listed else "Contents"
+            )
+            call(
+                "hda.get_hda_section_content",
+                node_path=node_path,
+                section_name=str(name),
+                allow_error=True,
+            )
+        call(
+            "hda.set_hda_section_content",
+            node_path=node_path,
+            section_name="Comment",
+            content="made by integration tests",
+            allow_error=True,
+        )
+        call("hda.update_hda", node_path=node_path, allow_error=True)
+        call("hda.reload_hda", file_path=hda_file, allow_error=True)
+        call("hda.install_hda", file_path=hda_file, force=True, allow_error=True)
+        call("hda.uninstall_hda", file_path=hda_file, allow_error=True)
+
+    def test_list_installed_hdas(self, call):
+        listed = call("hda.list_installed_hdas")
+        assert listed, listed
+
+
+class TestCache:
+    def test_cache_status_and_listing(self, call, tmp_path):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="cached"
+        )["node_path"]
+        box = call("nodes.create_node", parent_path=geo, node_type="box")["node_path"]
+        fc = call(
+            "nodes.create_node", parent_path=geo, node_type="filecache", name="cache1"
+        )["node_path"]
+        call("nodes.connect_nodes", source_path=box, dest_path=fc)
+        # Point the cache at tmp with an explicit file — the default
+        # constructed path resolves under $HIP, i.e. the repo checkout.
+        node = hou.node(fc)
+        if node.parm("filemethod") is not None:
+            node.parm("filemethod").set(1)
+        if node.parm("file") is not None:
+            node.parm("file").set(str(tmp_path / "box.bgeo.sc").replace("\\", "/"))
+        if node.parm("trange") is not None:
+            node.parm("trange").set(0)  # single frame, not 1-240
+
+        caches = call("cache.list_caches", root_path="/obj")
+        assert "cache1" in str(caches)
+        call("cache.get_cache_status", node_path=fc, allow_error=True)
+        call("cache.write_cache", node_path=fc, frame_range=[1, 1], allow_error=True)
+        call("cache.clear_cache", node_path=fc, allow_error=True)
+
+
+class TestCode:
+    def test_hscript_and_python(self, call):
+        out = call("code.execute_hscript", command="echo hello_houdini")
+        assert "hello_houdini" in str(out)
+        result = call(
+            "code.evaluate_expression", expression="1 + 1", language="python"
+        )
+        assert "2" in str(result)
+        env = call("code.get_env_variable", var_name="HFS")
+        assert "houdini" in str(env).lower() or "hfs" in str(env).lower()
+
+
+class TestContext:
+    def test_context_introspection(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="g"
+        )["node_path"]
+        box = call("nodes.create_node", parent_path=geo, node_type="box")["node_path"]
+        xform = call("nodes.create_node", parent_path=geo, node_type="xform")[
+            "node_path"
+        ]
+        call("nodes.connect_nodes", source_path=box, dest_path=xform)
+        chain = call("context.get_cook_chain", node_path=xform)
+        assert "box" in str(chain)
+        call("context.get_network_overview", path="/obj", depth=2)
+        call("context.set_selection", node_paths=[box])
+        selection = call("context.get_selection")
+        assert "box" in str(selection)
+        call("context.compare_snapshots", action="take", snapshot_name="t1")
+        call(
+            "context.compare_snapshots",
+            action="compare",
+            snapshot_name="t1",
+            allow_error=True,
+        )
+        call("context.get_node_errors_detailed", root_path="/obj")
+
+
+class TestRendering:
+    def test_geometry_rop_renders_a_real_file(self, call, tmp_path):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="g"
+        )["node_path"]
+        box = call("nodes.create_node", parent_path=geo, node_type="box")["node_path"]
+        rop = call(
+            "nodes.create_node", parent_path="/out", node_type="geometry", name="bake"
+        )["node_path"]
+        out_file = str(tmp_path / "baked.bgeo.sc").replace("\\", "/")
+        call(
+            "parameters.set_parameters",
+            node_path=rop,
+            params={"soppath": box, "sopoutput": out_file},
+        )
+        call("rendering.start_render", node_path=rop)
+        assert (tmp_path / "baked.bgeo.sc").is_file(), (
+            "start_render claimed success but wrote no file"
+        )
+        call("rendering.get_render_progress", node_path=rop, allow_error=True)
+
+    def test_render_settings_roundtrip(self, call):
+        created = call(
+            "rendering.create_render_node", renderer="mantra", name="m1", allow_error=True
+        )
+        if created["status"] != "success":
+            pytest.skip(str(created["error"]["message"]))
+        rop = created["data"].get("node_path", "/out/m1")
+        settings = call("rendering.get_render_settings", node_path=rop)
+        assert settings, settings
+        call(
+            "rendering.set_render_settings",
+            node_path=rop,
+            settings={"vm_samples": 2},
+            allow_error=True,
+        )
+
+    def test_viewport_renders_fail_cleanly_headless(self, call, tmp_path):
+        if hou.isUIAvailable():
+            pytest.skip("graphical session")
+        out = str(tmp_path / "vp.png").replace("\\", "/")
+        for command in ("rendering.render_viewport", "rendering.render_quad_view"):
+            result = call(command, output_path=out, allow_error=True)
+            assert result["status"] in ("success", "error")
+
+
+class TestViewportHeadless:
+    """Every viewport command must degrade cleanly without a UI."""
+
+    @pytest.mark.parametrize(
+        ("command", "params"),
+        [
+            ("viewport.list_panes", {}),
+            ("viewport.get_viewport_info", {}),
+            ("viewport.set_viewport_display", {"display_mode": "smooth"}),
+            ("viewport.set_viewport_direction", {"direction": "top"}),
+            ("viewport.set_viewport_renderer", {"renderer": "Houdini GL"}),
+            ("viewport.frame_all", {}),
+            ("viewport.frame_selection", {}),
+            ("viewport.set_current_network", {"network_path": "/obj"}),
+            ("viewport.find_error_nodes", {}),
+        ],
+    )
+    def test_clean_headless_behavior(self, call, command, params):
+        result = call(command, allow_error=True, **params)
+        assert result["status"] in ("success", "error")
+
+
+class TestRemainingNodesParamsScene:
+    def test_move_reorder_color(self, call):
+        geo_a = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="a"
+        )["node_path"]
+        geo_b = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="b"
+        )["node_path"]
+        box = call("nodes.create_node", parent_path=geo_a, node_type="box")["node_path"]
+        moved = call("nodes.move_node", node_path=box, dest_parent=geo_b)
+        assert hou.node(moved["new_path"]).parent().path() == geo_b
+        call("nodes.set_node_color", node_path=moved["new_path"], r=1.0, g=0.0, b=0.0)
+        assert list(hou.node(moved["new_path"]).color().rgb()) == [1.0, 0.0, 0.0]
+
+        merge = call("nodes.create_node", parent_path=geo_b, node_type="merge")[
+            "node_path"
+        ]
+        s1 = call("nodes.create_node", parent_path=geo_b, node_type="sphere")[
+            "node_path"
+        ]
+        call(
+            "nodes.connect_nodes_batch",
+            connections=[
+                {"source_path": moved["new_path"], "dest_path": merge, "input_index": 0},
+                {"source_path": s1, "dest_path": merge, "input_index": 1},
+            ],
+        )
+        call("nodes.reorder_inputs", node_path=merge, new_order=[1, 0])
+        assert hou.node(merge).inputs()[0].path() == s1
+
+    def test_parameter_extras(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="g"
+        )["node_path"]
+        box = call("nodes.create_node", parent_path=geo, node_type="box")["node_path"]
+        call("parameters.set_expression", node_path=box, parm_name="tx", expression="$F")
+        expr = call("parameters.get_expression", node_path=box, parm_name="tx")
+        assert "$F" in str(expr)
+        call("parameters.set_parameter", node_path=box, parm_name="sizex", value=9.0)
+        call("parameters.revert_parameter", node_path=box, parm_name="sizex")
+        assert hou.node(box).parm("sizex").isAtDefault()
+        call(
+            "parameters.create_spare_parameters",
+            node_path=box,
+            parameters=[
+                {"parm_name": "amount", "parm_type": "float", "label": "Amount"},
+                {"parm_name": "label_text", "parm_type": "string", "label": "Label"},
+            ],
+            folder_name="Custom",
+        )
+        assert hou.node(box).parm("amount") is not None
+
+    def test_scene_save_and_load(self, call, tmp_path):
+        call("nodes.create_node", parent_path="/obj", node_type="geo", name="persisted")
+        hip = str(tmp_path / "scene.hip").replace("\\", "/")
+        call("scene.save_scene", file_path=hip)
+        call("scene.new_scene")
+        assert hou.node("/obj/persisted") is None
+        call("scene.load_scene", file_path=hip)
+        assert hou.node("/obj/persisted") is not None
+
+
+class TestMaterialsModule:
+    def test_material_network_and_info(self, call):
+        created = call(
+            "materials.create_material_network",
+            name="brushed_metal",
+            shader_type="principled",
+            params={"rough": 0.3},
+        )
+        path = created.get("material_path", created.get("node_path"))
+        assert path and hou.node(path) is not None, created
+        info = call("materials.get_material_info", node_path=path)
+        assert info, info
+        listed = call("materials.list_materials", root_path="/mat")
+        assert "brushed_metal" in str(listed)
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="g"
+        )["node_path"]
+        call("nodes.create_node", parent_path=geo, node_type="box")
+        call("materials.assign_material", geo_path=geo, material_path=path)
+
+
+class TestLopsModule:
+    @pytest.fixture
+    def stage(self, call) -> str:
+        lopnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="lopnet", name="stage"
+        )["node_path"]
+        sphere = call(
+            "lops.create_lop_node",
+            parent_path=lopnet,
+            lop_type="sphere",
+            prim_path="/geo/ball",
+        )
+        return sphere["node_path"]
+
+    def test_usd_stage_walkthrough(self, call, stage):
+        prim = call("lops.get_usd_prim", node_path=stage, prim_path="/geo/ball")
+        assert "Sphere" in str(prim)
+        set_result = call(
+            "lops.set_usd_attribute",
+            node_path=stage,
+            prim_path="/geo/ball",
+            attr_name="radius",
+            value=3.0,
+        )
+        # set_usd_attribute appends a Python LOP; read back through it.
+        out_node = set_result["python_node"]
+        radius = call(
+            "lops.get_usd_attribute",
+            node_path=out_node,
+            prim_path="/geo/ball",
+            attr_name="radius",
+        )
+        assert "3" in str(radius.get("value", radius)), radius
+        call("lops.get_usd_layers", node_path=stage)
+        call("lops.inspect_usd_layer", node_path=stage, layer_index=0, allow_error=True)
+        call("lops.get_usd_prim_stats", node_path=stage)
+        call("lops.get_last_modified_prims", node_path=stage)
+        found = call("lops.find_usd_prims", node_path=stage, pattern="*ball*")
+        assert "ball" in str(found)
+        call("lops.get_usd_composition", node_path=stage, prim_path="/geo/ball")
+        call("lops.get_usd_variants", node_path=stage, prim_path="/geo/ball")
+        call("lops.get_usd_materials", node_path=stage)
+
+    def test_usd_lighting(self, call):
+        lopnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="lopnet", name="lights"
+        )["node_path"]
+        light = call(
+            "lops.create_light", parent_path=lopnet, light_type="dome", intensity=2.0
+        )
+        light_node = light.get("node_path")
+        assert light_node and hou.node(light_node) is not None, light
+        lights = call("lops.list_lights", node_path=light_node)
+        assert lights, lights
+        prim_path = light.get("prim_path")
+        if prim_path:
+            call(
+                "lops.set_light_properties",
+                node_path=light_node,
+                prim_path=prim_path,
+                properties={"intensity": 5.0},
+                allow_error=True,
+            )
+
+
+class TestMopUp:
+    """Exercise the commands no other test reaches."""
+
+    def test_geometry_inspection_extras(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="g"
+        )["node_path"]
+        box = call("nodes.create_node", parent_path=geo, node_type="box")["node_path"]
+        grp = call(
+            "nodes.create_node", parent_path=geo, node_type="groupcreate", name="top_grp"
+        )["node_path"]
+        call("nodes.connect_nodes", source_path=box, dest_path=grp)
+        values = call(
+            "geometry.get_attrib_values", node_path=box, attrib_name="P", count=8
+        )
+        assert values["total_elements"] == 8
+        assert len(values["values"]) == 8 * 3
+        info = call(
+            "geometry.get_attribute_info", node_path=box, attrib_name="P"
+        )
+        assert info, info
+        groups = call("geometry.get_groups", node_path=grp)
+        assert "top_grp" in str(groups), groups
+        members = call(
+            "geometry.get_group_members",
+            node_path=grp,
+            group_name="top_grp",
+            group_type="prim",
+        )
+        assert members, members
+
+    def test_context_and_scene_extras(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="g"
+        )["node_path"]
+        explained = call("context.explain_node", node_path=geo)
+        assert "geo" in str(explained)
+        call("context.get_scene_summary")
+        ctx = call("scene.get_context_info", context="/obj")
+        assert ctx, ctx
+        schema = call(
+            "parameters.get_parameter_schema", node_path=geo, filter="translate"
+        )
+        assert "tx" in str(schema) or "translate" in str(schema).lower()
+
+    def test_vex_extras(self, call):
+        call("nodes.create_node", parent_path="/obj", node_type="geo", name="g")
+        wrangle = call(
+            "vex.create_wrangle", parent_path="/obj/g", vex_code="@Cd = {1,1,1};"
+        )["node_path"]
+        call("vex.set_wrangle_code", node_path=wrangle, vex_code="@Cd = {0,0,1};")
+        code = call("vex.get_wrangle_code", node_path=wrangle)
+        assert "{0,0,1}" in str(code)
+        validated = call("vex.validate_vex", node_path=wrangle)
+        assert validated["is_valid"] is True, validated
+        call(
+            "vex.create_vex_expression",
+            node_path=wrangle,
+            parm_name="tx",
+            expression="@Frame",
+            allow_error=True,
+        )
+
+    def test_lops_and_materials_extras(self, call):
+        lopnet = call(
+            "nodes.create_node", parent_path="/obj", node_type="lopnet", name="stage"
+        )["node_path"]
+        sphere = call(
+            "lops.create_lop_node", parent_path=lopnet, lop_type="sphere"
+        )["node_path"]
+        call("lops.get_stage_info", node_path=sphere)
+        prims = call("lops.list_usd_prims", node_path=sphere)
+        assert prims, prims
+        rig = call("lops.create_light_rig", parent_path=lopnet, preset="three_point")
+        assert rig, rig
+        types = call("materials.list_material_types")
+        assert "principled" in str(types)
+
+    def test_rendering_and_viewport_extras(self, call, tmp_path):
+        rops = call("rendering.list_render_nodes")
+        assert rops is not None
+        out = str(tmp_path / "net.png").replace("\\", "/")
+        call(
+            "rendering.render_node_network",
+            node_path="/obj",
+            output_path=out,
+            allow_error=True,
+        )
+        cam = call(
+            "nodes.create_node", parent_path="/obj", node_type="cam", name="cam1"
+        )["node_path"]
+        call("viewport.set_viewport_camera", camera_path=cam, allow_error=True)
+
+    def test_flip_and_vellum_workflows_build_real_networks(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="src"
+        )["node_path"]
+        sphere = call("nodes.create_node", parent_path=geo, node_type="sphere")
+        flip = call(
+            "workflow.setup_flip_sim",
+            source_geo=sphere["node_path"],
+            allow_error=True,
+        )
+        if flip["status"] == "success":
+            for path in flip["data"].get("all_nodes", []):
+                assert hou.node(path) is not None, f"claimed node missing: {path}"
+        cloth_geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="cloth"
+        )["node_path"]
+        call("nodes.create_node", parent_path=cloth_geo, node_type="grid")
+        vellum = call(
+            "workflow.setup_vellum_sim", geo_path=cloth_geo, allow_error=True
+        )
+        if vellum["status"] == "success":
+            for path in vellum["data"].get("all_nodes", []):
+                assert hou.node(path) is not None, f"claimed node missing: {path}"
+
+
+class TestAnimationModule:
+    def test_remaining_animation_commands(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="g"
+        )["node_path"]
+        call(
+            "animation.set_keyframes",
+            node_path=geo,
+            parm_name="tx",
+            keyframes=[{"frame": 1, "value": 0.0}, {"frame": 10, "value": 2.0}],
+        )
+        call("animation.delete_keyframe", node_path=geo, parm_name="tx", frame=10)
+        keys = call("animation.get_keyframes", node_path=geo, parm_name="tx")
+        assert "1" in str(keys), keys
+        call("animation.set_frame_range", start=1, end=100)
+        assert hou.playbar.frameRange() == hou.Vector2(1, 100)
+        call("animation.set_playback_range", start=1, end=50)
+        call("animation.set_frame", frame=25)
+        frame = call("animation.get_frame")
+        assert "25" in str(frame)
+        call("animation.playbar_control", action="stop", allow_error=True)

--- a/tests/integration/test_instruction_accuracy_live.py
+++ b/tests/integration/test_instruction_accuracy_live.py
@@ -1,0 +1,102 @@
+"""Verify the node names advertised in server_instructions.md exist.
+
+The instructions tell assistants to trust specific built-in node names
+(the COMMONLY MISSED NODE DOMAINS lists). Any name that does not exist
+in this Houdini version is guidance that makes the assistant hallucinate.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import re
+from pathlib import Path
+
+# Third-party
+import hou
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_MD = (
+    Path(__file__).resolve().parents[2]
+    / "python"
+    / "fxhoudinimcp"
+    / "prompts"
+    / "markdown"
+    / "server_instructions.md"
+)
+
+# Optional packs not shipped with a base install.
+_OPTIONAL_PREFIXES = ("labs::", "apex::")
+
+# Markdown sections mapped to hou node type categories.
+_SECTIONS = {
+    "### SOPs": "Sop",
+    "### LOPs": "Lop",
+    "### DOPs": "Dop",
+    "### COPs": "Cop",
+    "### CHOPs": "Chop",
+    "### TOPs": "Top",
+}
+
+
+def _claimed_names() -> list[tuple[str, str]]:
+    """Extract (category, node_type_name) claims from the instructions."""
+    text = _MD.read_text(encoding="utf-8").replace("\\_", "_")
+    claims: list[tuple[str, str]] = []
+    category = None
+    for line in text.splitlines():
+        if line.startswith("### "):
+            category = next(
+                (cat for prefix, cat in _SECTIONS.items() if line.startswith(prefix)),
+                None,
+            )
+            continue
+        if category is None or not line.startswith("*"):
+            continue
+        # Node names appear after the colon, comma-separated. Only tokens
+        # that look like node type names (identifier characters only).
+        # Parenthesized fragments are prose, not type names.
+        _, _, tail = line.partition(":")
+        tail = re.sub(r"\([^)]*\)", "", tail)
+        for chunk in re.split(r"[,—]", tail):
+            token = chunk.strip().rstrip(".")
+            if re.fullmatch(r"[a-z][a-z0-9_:.]*[a-z0-9]", token) and (
+                "_" in token or "::" in token or len(token) >= 4
+            ):
+                claims.append((category, token))
+    return claims
+
+
+def _exists(category_types: dict, name: str) -> bool:
+    if name in category_types:
+        return True
+    prefix = name + "::"
+    return any(key.startswith(prefix) for key in category_types)
+
+
+def test_every_advertised_node_type_exists():
+    claims = _claimed_names()
+    assert len(claims) > 150, f"parser broke, only {len(claims)} claims found"
+
+    categories = hou.nodeTypeCategories()
+    missing: list[str] = []
+    optional_missing: list[str] = []
+    for category_name, node_name in claims:
+        category = categories.get(category_name)
+        if category is None:
+            missing.append(f"{category_name}: category itself missing")
+            continue
+        if _exists(category.nodeTypes(), node_name):
+            continue
+        if node_name.startswith(_OPTIONAL_PREFIXES):
+            optional_missing.append(f"{category_name}/{node_name}")
+        else:
+            missing.append(f"{category_name}/{node_name}")
+
+    if optional_missing:
+        print(f"[info] optional packs not installed: {len(optional_missing)} names")
+    assert not missing, (
+        f"server_instructions.md advertises {len(missing)} node types that "
+        f"do not exist in {hou.applicationVersionString()}: {missing}"
+    )

--- a/tests/integration/test_user_scenarios_live.py
+++ b/tests/integration/test_user_scenarios_live.py
@@ -181,6 +181,42 @@ class TestLookdevScenario:
         assert hou.node(render["rop_path"]) is not None
         assert hou.node(render["camera_path"]) is not None
 
+    def test_actual_image_render(self, call, tmp_path):
+        """User: 'Render me a frame.' — a real 64x64 mantra render to disk."""
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="subject"
+        )["node_path"]
+        call("nodes.create_node", parent_path=geo, node_type="sphere")
+        render = call(
+            "workflow.setup_render",
+            renderer="mantra",
+            resolution=[64, 64],
+            samples=1,
+            name="micro",
+        )
+        out = str(tmp_path / "frame.exr").replace("\\", "/")
+        call(
+            "parameters.set_parameter",
+            node_path=render["rop_path"],
+            parm_name="vm_picture",
+            value=out,
+        )
+        result = call(
+            "rendering.start_render",
+            node_path=render["rop_path"],
+            frame_range=[1, 1],
+            allow_error=True,
+        )
+        data = result.get("data", {})
+        if result["status"] != "success" or not data.get("success", True):
+            reason = str(
+                result.get("error", {}).get("message") or data.get("error")
+            )[:80]
+            pytest.skip(f"mantra render unavailable here: {reason}")
+        assert (tmp_path / "frame.exr").is_file(), (
+            "start_render claimed success but no image was written"
+        )
+
 
 class TestScreenshotScenario:
     """User: 'Show me what it looks like.' — headless behavior must be a

--- a/tests/integration/test_user_scenarios_live.py
+++ b/tests/integration/test_user_scenarios_live.py
@@ -1,0 +1,216 @@
+"""End-to-end scenarios: the tool-call sequences an instruction-following
+assistant would run for real user requests, verified against the live scene.
+
+Each scenario follows the server instructions: discover node types first
+(NODE-FIRST RULE), prefer workflow tools and native nodes, log status,
+lay out networks, and leave the display flag on the result.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import time
+
+# Third-party
+import hou
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestProceduralModelingScenario:
+    """User: 'Create a procedural rocky terrain with scattered rocks.'"""
+
+    def test_node_discovery_surfaces_the_right_builtins(self, call):
+        """The NODE-FIRST RULE only works if list_node_types actually
+        surfaces the built-in nodes the instructions promise."""
+        for keyword, expected_prefix in [
+            ("heightfield", "heightfield"),
+            ("scatter", "scatter"),
+            ("copy", "copytopoints"),
+            ("mountain", "mountain"),
+        ]:
+            data = call("nodes.list_node_types", context="Sop", filter=keyword)
+            names = [t["name"] for t in data["types"]]
+            assert any(n.startswith(expected_prefix) for n in names), (
+                f"filter={keyword!r} did not surface {expected_prefix!r}: "
+                f"{names[:10]}"
+            )
+
+    def test_full_terrain_build(self, call):
+        call("viewport.log_status", message="Creating terrain...")
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="terrain"
+        )["node_path"]
+
+        chain = call(
+            "workflow.build_sop_chain",
+            parent_path=geo,
+            steps=[
+                {"type": "grid", "params": {"rows": 60, "cols": 60}},
+                {"type": "mountain", "params": {"height": 2.0}},
+                {"type": "scatter", "params": {"npts": 50}},
+            ],
+        )
+        scatter_path = chain["nodes"][-1]["path"]
+
+        rock = call(
+            "nodes.create_node", parent_path=geo, node_type="box", name="rock"
+        )["node_path"]
+        call(
+            "parameters.set_parameter", node_path=rock, parm_name="scale", value=0.1
+        )
+        copy = call(
+            "nodes.create_node",
+            parent_path=geo,
+            node_type="copytopoints::2.0",
+            name="copy_rocks",
+        )["node_path"]
+        call(
+            "nodes.connect_nodes_batch",
+            connections=[
+                {"source_path": rock, "dest_path": copy, "input_index": 0},
+                {"source_path": scatter_path, "dest_path": copy, "input_index": 1},
+            ],
+        )
+        call("nodes.set_node_flags", node_path=copy, display=True, render=True)
+        call("nodes.layout_children", parent_path=geo)
+        call("viewport.log_status", message="Terrain done.")
+
+        # The user-facing outcome: displayed geometry is 50 copied rocks.
+        info = call("geometry.get_geometry_info", node_path=copy)
+        assert info["num_points"] == 50 * 8, info["num_points"]
+        assert info["num_prims"] == 50 * 6, info["num_prims"]
+        node = hou.node(copy)
+        assert node.isDisplayFlagSet()
+        assert not node.errors()
+
+
+class TestSimulationScenario:
+    """User: 'Make a smoke simulation that looks like a campfire plume.'"""
+
+    def test_pyro_sim_produces_actual_smoke(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="fire"
+        )["node_path"]
+        source = call(
+            "nodes.create_node", parent_path=geo, node_type="sphere", name="emitter"
+        )["node_path"]
+        call("parameters.set_parameter", node_path=source, parm_name="scale", value=0.3)
+
+        sim = call("workflow.setup_pyro_sim", source_geo=source, name="campfire")
+        assert sim["success"] is True
+
+        # Keep the sim cheap: coarse voxels if the solver exposes divsize.
+        solver = sim["solver_path"]
+        if hou.node(solver).parm("divsize") is not None:
+            call(
+                "parameters.set_parameter",
+                node_path=solver,
+                parm_name="divsize",
+                value=0.2,
+            )
+
+        # Advance a few frames and verify smoke volumes actually exist —
+        # the part a user sees, and the part success flags can't fake.
+        start = time.perf_counter()
+        call("animation.set_frame", frame=5)
+        info = call("geometry.get_geometry_info", node_path=solver)
+        cook_seconds = time.perf_counter() - start
+        print(f"[scenario] pyro cook to frame 5: {cook_seconds:.1f}s")
+
+        breakdown = info["prim_type_breakdown"]
+        assert any(
+            "Volume" in type_name or "VDB" in type_name
+            for type_name in breakdown
+        ), f"no smoke volumes at frame 5: {breakdown}"
+        assert cook_seconds < 60, f"pyro cook too slow: {cook_seconds:.1f}s"
+
+
+class TestAnimationScenario:
+    """User: 'Animate a bouncing ball.'"""
+
+    def test_keyframed_ball_evaluates_midair(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="ball"
+        )["node_path"]
+        call("nodes.create_node", parent_path=geo, node_type="sphere")
+        for frame, value in [(1, 0.0), (12, 5.0), (24, 0.0)]:
+            call(
+                "animation.set_keyframe",
+                node_path=geo,
+                parm_name="ty",
+                frame=frame,
+                value=value,
+            )
+        keys = call("animation.get_keyframes", node_path=geo, parm_name="ty")
+        assert "3" in str(keys.get("count", keys)), keys
+
+        call("animation.set_frame", frame=12)
+        assert hou.node(geo).parm("ty").eval() == pytest.approx(5.0)
+        call("animation.set_frame", frame=1)
+        assert hou.node(geo).parm("ty").eval() == pytest.approx(0.0)
+
+
+class TestLookdevScenario:
+    """User: 'Shade the terrain red and set up a render.'"""
+
+    def test_material_render_pipeline(self, call):
+        geo = call(
+            "nodes.create_node", parent_path="/obj", node_type="geo", name="asset"
+        )["node_path"]
+        call("nodes.create_node", parent_path=geo, node_type="testgeometry_pighead")
+        mat = call(
+            "workflow.create_material",
+            name="red_clay",
+            base_color=[0.8, 0.1, 0.1],
+            roughness=0.9,
+        )
+        call(
+            "workflow.assign_material",
+            geo_path=geo,
+            material_path=mat["material_path"],
+        )
+        render = call(
+            "workflow.setup_render",
+            renderer="mantra",
+            resolution=[320, 240],
+            samples=4,
+            name="preview",
+        )
+        assert hou.node(render["rop_path"]) is not None
+        assert hou.node(render["camera_path"]) is not None
+
+
+class TestScreenshotScenario:
+    """User: 'Show me what it looks like.' — headless behavior must be a
+    clean, actionable error, not a Python traceback."""
+
+    def test_viewport_screenshot_fails_gracefully_headless(self, call):
+        if hou.isUIAvailable():
+            pytest.skip("graphical session: screenshots are exercised by GUI use")
+        error = call("viewport.capture_screenshot", expect_error=True)
+        message = error["message"].lower()
+        assert message.strip(), "empty error message"
+        assert any(
+            hint in message
+            for hint in ("ui", "graphical", "viewport", "headless", "gui")
+        ), f"unhelpful headless error: {error['message']}"
+
+    def test_network_editor_capture_fails_gracefully_headless(self, call):
+        if hou.isUIAvailable():
+            pytest.skip("graphical session: captures are exercised by GUI use")
+        call("nodes.create_node", parent_path="/obj", node_type="geo", name="g")
+        error = call(
+            "viewport.capture_network_editor", expect_error=True
+        )
+        message = error["message"].lower()
+        assert any(
+            hint in message
+            for hint in ("ui", "graphical", "network editor", "headless", "gui")
+        ), f"unhelpful headless error: {error['message']}"
+
+    def test_log_status_is_harmless_headless(self, call):
+        # Instructions say to call log_status constantly; it must never
+        # break a headless session.
+        call("viewport.log_status", message="working...")

--- a/tests/run_integration.ps1
+++ b/tests/run_integration.ps1
@@ -1,39 +1,5 @@
-# Runs the integration test suite inside hython (Houdini's Python).
-#
-# Usage:
-#   tests/run_integration.ps1                 # whole integration suite
-#   tests/run_integration.ps1 -k materials    # pytest args pass through
-#
-# Requires a Houdini installation (consumes one license seat) and pytest
-# installed for a CPython matching hython's major.minor version.
-# Override auto-detection with the HYTHON environment variable.
-
+# Thin wrapper: the cross-platform launcher lives in run_integration.py.
+# Usage: tests/run_integration.ps1 [pytest args...]
 $ErrorActionPreference = "Stop"
-$repoRoot = Split-Path -Parent $PSScriptRoot
-
-if ($env:HYTHON -and (Test-Path $env:HYTHON)) {
-    $hython = $env:HYTHON
-} else {
-    $installs = Get-ChildItem "C:\Program Files\Side Effects Software" -Directory -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -match "^Houdini \d+\.\d+" } |
-        Sort-Object { [version]($_.Name -replace "Houdini ", "") } -Descending
-    $hython = $installs |
-        ForEach-Object { Join-Path $_.FullName "bin\hython.exe" } |
-        Where-Object { Test-Path $_ } |
-        Select-Object -First 1
-    if (-not $hython) {
-        throw "No hython.exe found under 'C:\Program Files\Side Effects Software'. Set HYTHON to its full path."
-    }
-}
-
-# Reuse the system Python's site-packages for pytest and plugins.
-$sitePackages = & python -c "import pytest, os; print(os.path.dirname(os.path.dirname(pytest.__file__)))"
-if ($LASTEXITCODE -ne 0) {
-    throw "Could not locate pytest via 'python'. Install it: python -m pip install pytest pytest-asyncio"
-}
-
-$env:PYTHONPATH = "$repoRoot\python;$sitePackages"
-Write-Host "Using hython: $hython"
-
-& $hython -m pytest "$repoRoot\tests\integration" -q -s --durations=15 @args
+& python "$PSScriptRoot/run_integration.py" @args
 exit $LASTEXITCODE

--- a/tests/run_integration.py
+++ b/tests/run_integration.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Launch the integration test suite inside hython on Windows, macOS, or Linux.
+
+Usage:
+    python tests/run_integration.py              # whole integration suite
+    python tests/run_integration.py -k pyro      # pytest args pass through
+
+Finds the newest installed Houdini (override with the HYTHON environment
+variable pointing at the hython executable) and reuses this interpreter's
+pytest installation via PYTHONPATH. Requires a Houdini license seat.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_SEARCH_PATTERNS = [
+    # Windows
+    "C:/Program Files/Side Effects Software/Houdini *",
+    # macOS
+    "/Applications/Houdini/Houdini*",
+    # Linux
+    "/opt/hfs*",
+]
+
+_HYTHON_SUBPATHS = [
+    "bin/hython.exe",
+    "bin/hython",
+    "Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython",
+]
+
+
+def _version_key(path: Path) -> tuple[int, ...]:
+    digits = re.findall(r"\d+", path.name)
+    return tuple(int(d) for d in digits) if digits else (0,)
+
+
+def find_hython() -> Path:
+    """Return the hython executable: $HYTHON, newest install, or PATH."""
+    env_override = os.environ.get("HYTHON")
+    if env_override:
+        candidate = Path(env_override)
+        if candidate.is_file():
+            return candidate
+        sys.exit(f"HYTHON is set but does not exist: {env_override}")
+
+    installs: list[Path] = []
+    for pattern in _SEARCH_PATTERNS:
+        root = Path(pattern.split("*")[0]).parent
+        glob = pattern.split("/")[-1]
+        if root.is_dir():
+            installs.extend(p for p in root.glob(glob) if p.is_dir())
+
+    for install in sorted(installs, key=_version_key, reverse=True):
+        for subpath in _HYTHON_SUBPATHS:
+            hython = install / subpath
+            if hython.is_file():
+                return hython
+
+    on_path = shutil.which("hython")
+    if on_path:
+        return Path(on_path)
+
+    sys.exit(
+        "No hython executable found. Install Houdini or set the HYTHON "
+        "environment variable to the full path of hython."
+    )
+
+
+def main() -> int:
+    hython = find_hython()
+
+    try:
+        import pytest  # noqa: F401
+
+        site_packages = Path(pytest.__file__).resolve().parent.parent
+    except ImportError:
+        sys.exit(
+            "pytest is not importable from this Python. Install it first: "
+            f"{sys.executable} -m pip install pytest"
+        )
+
+    env = os.environ.copy()
+    python_path = [str(REPO_ROOT / "python"), str(site_packages)]
+    if env.get("PYTHONPATH"):
+        python_path.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(python_path)
+
+    print(f"Using hython: {hython}")
+    command = [
+        str(hython),
+        "-m",
+        "pytest",
+        str(REPO_ROOT / "tests" / "integration"),
+        "-q",
+        "-s",
+        "--durations=15",
+        *sys.argv[1:],
+    ]
+    return subprocess.call(command, env=env, cwd=str(REPO_ROOT))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/run_integration.sh
+++ b/tests/run_integration.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Thin wrapper: the cross-platform launcher lives in run_integration.py.
+# Usage: tests/run_integration.sh [pytest args...]
+exec python3 "$(dirname "$0")/run_integration.py" "$@"

--- a/tests/test_prompts_resources.py
+++ b/tests/test_prompts_resources.py
@@ -1,0 +1,103 @@
+"""Tests for MCP prompt templates and resources.
+
+Prompts must render with no leftover {placeholders}; resources must
+delegate to the right bridge commands with valid arguments.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import re
+
+# Third-party
+import pytest
+
+# Internal
+from fxhoudinimcp.prompts.workflows import (
+    debug_scene,
+    hda_development,
+    pdg_pipeline,
+    procedural_modeling_workflow,
+    simulation_setup,
+    usd_scene_assembly,
+)
+from fxhoudinimcp.resources.geo_resources import geo_summary
+from fxhoudinimcp.resources.scene_resources import (
+    installed_hdas,
+    node_info,
+    node_types,
+    scene_errors,
+    scene_info,
+    scene_tree,
+)
+from fxhoudinimcp.resources.usd_resources import usd_stage
+
+_PLACEHOLDER = re.compile(r"\{[a-z_]+\}")
+
+
+class TestPromptTemplates:
+    @pytest.mark.parametrize(
+        ("render", "marker"),
+        [
+            (lambda: procedural_modeling_workflow("a rocky cliff"), "rocky cliff"),
+            (lambda: usd_scene_assembly("a desert at dusk"), "desert at dusk"),
+            (lambda: simulation_setup("pyro", "a campfire"), "campfire"),
+            (lambda: pdg_pipeline("wedge 10 variants"), "wedge 10 variants"),
+            (lambda: hda_development("a rock generator"), "rock generator"),
+            (lambda: debug_scene("slow cooking"), "slow cooking"),
+        ],
+        ids=["procedural", "usd", "simulation", "pdg", "hda", "debug"],
+    )
+    def test_prompt_renders_completely(self, render, marker):
+        text = render()
+        assert marker in text
+        leftovers = _PLACEHOLDER.findall(text)
+        assert not leftovers, f"unrendered placeholders: {leftovers}"
+
+    def test_housekeeping_block_is_injected(self):
+        text = procedural_modeling_workflow("anything")
+        assert "log_status" in text
+        assert "{network_housekeeping}" not in text
+
+
+class TestResources:
+    @pytest.mark.asyncio
+    async def test_scene_resources_delegate(self, mock_ctx, mock_bridge):
+        await scene_info(mock_ctx)
+        mock_bridge.execute.assert_called_with("scene.get_scene_info", {})
+
+        await node_info("obj/geo1", mock_ctx)
+        mock_bridge.execute.assert_called_with(
+            "nodes.get_node_info", {"node_path": "/obj/geo1"}
+        )
+
+        await scene_tree(mock_ctx)
+        # "/" is a real node path; the old "all" value crashed the handler.
+        mock_bridge.execute.assert_called_with(
+            "scene.get_context_info", {"context": "/"}
+        )
+
+        await scene_errors(mock_ctx)
+        mock_bridge.execute.assert_called_with(
+            "viewport.find_error_nodes", {"root_path": "/"}
+        )
+
+        await node_types("Sop", mock_ctx)
+        mock_bridge.execute.assert_called_with(
+            "nodes.list_node_types", {"context": "Sop"}
+        )
+
+        await installed_hdas(mock_ctx)
+        mock_bridge.execute.assert_called_with("hda.list_installed_hdas", {})
+
+    @pytest.mark.asyncio
+    async def test_geo_and_usd_resources_delegate(self, mock_ctx, mock_bridge):
+        await geo_summary("obj/geo1/box1", mock_ctx)
+        command, params = mock_bridge.execute.call_args.args
+        assert command == "geometry.get_geometry_info"
+        assert params["node_path"].startswith("/")
+
+        await usd_stage("obj/lopnet1/sphere1", mock_ctx)
+        command, params = mock_bridge.execute.call_args.args
+        assert command == "lops.get_stage_info"
+        assert params["node_path"].startswith("/")


### PR DESCRIPTION
## Summary

Top of the test stack (#6 -> #7 -> this). Three things:

**1. Real user-facing scenarios** (`test_user_scenarios_live.py`) — replays the exact tool-call sequences an instruction-following assistant runs for real requests, verified against the live scene:
- *"Create a procedural rocky terrain with scattered rocks"* — asserts the NODE-FIRST discovery path works (`list_node_types` surfaces heightfield/scatter/copytopoints/mountain), builds the chain, wires copies, and the displayed geometry is exactly 50 rocks with no cook errors.
- *"Make a smoke simulation"* — builds the pyro network and **cooks it to frame 5, asserting real smoke volumes exist** (0.5 s) — the thing success flags can't fake.
- *"Animate a bouncing ball"* — keyframes evaluate mid-air at the right frames.
- *"Shade it / set up a render / show me what it looks like"* — material+render pipeline, plus screenshot behavior: headless captures must fail with actionable messages, and `log_status` must never break.

**2. Instruction accuracy + full command coverage**
- `test_instruction_accuracy_live.py` parses every node name advertised in `server_instructions.md` and asserts it exists in the running Houdini. **It found 60 phantom names** — an entire COPs section of legacy COP2 names presented as Copernicus, renamed KineFX/VDB/hair nodes, and never-existed types (`camerafrust`, `fanforce`, `rigsolver`, `grunge_*`, ...). The instructions now contain only live-verified names, so assistants stop being steered into `create_node` failures.
- `test_command_coverage_live.py` exercises every remaining command; the conftest now prints session coverage: **173/173 commands**.

**3. Cross-platform runner** — `tests/run_integration.py` works on Windows, macOS, and Linux (install discovery for all three + `HYTHON` override); `run_integration.ps1`/`run_integration.sh` are thin wrappers.

## Handler bugs found by these tests, fixed here

- `viewport.log_status` crashed headless (`hou.ui` missing) even though the instructions mandate calling it at every step — now a clean no-op printing to stdout.
- `chops.get_chop_data` crashed on every call (`hou.Clip` has no `.start()`; uses `sampleRange()` now).
- `lops.set_usd_attribute` never worked (`"python"` is not a LOP type name; `"pythonscript"` is).
- `lops.get_usd_composition` crashed (`Pcp.PrimIndex` has no `nodeRange`; walks from `rootNode`).
- `cops.list_cop_node_types` listed legacy Cop2 types while `create_cop_node` creates Copernicus nodes — the discover-then-create loop could never succeed; now lists the `Cop` category.

## Testing

- `python tests/run_integration.py` — **98 passed, 173/173 command coverage**, Houdini 21.0.440.
- `pytest tests/` — 74 passed; `ruff check` clean on all new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)