### PR TITLE
Houdini 22 support: python3.13libs, USD 0.26.5, PDG deadlock, reconnect, hou.pdg removal

### DIFF
--- a/houdini/python3.13libs/uiready.py
+++ b/houdini/python3.13libs/uiready.py
@@ -1,0 +1,18 @@
+"""Auto-start FXHoudini-MCP server when Houdini's UI is ready.
+
+This script is sourced by Houdini once at startup, after the UI is
+initialised.  Unlike scripts/456.py it stacks correctly with other
+packages that also define a uiready.py.
+
+Set FXHOUDINIMCP_AUTOSTART=0 to disable auto-start.
+"""
+
+import os
+
+if os.environ.get("FXHOUDINIMCP_AUTOSTART", "1") == "1":
+    try:
+        import fxhoudinimcp_server.startup
+
+        fxhoudinimcp_server.startup.ensure_running()
+    except Exception as e:
+        print(f"[fxhoudinimcp] Auto-start failed: {e}")

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/lops_handlers.py
@@ -423,13 +423,13 @@ def _get_last_modified_prims(*, node_path: str) -> dict[str, Any]:
         spec = layer.GetPrimAtPath(path)
         if spec:
             authored.append(str(path))
-            for child_name in spec.nameChildren:
+            for child_name in spec.nameChildren.keys():
                 _walk(path.AppendChild(child_name))
 
     root = Sdf.Path.absoluteRootPath
     root_spec = layer.GetPrimAtPath(root)
     if root_spec:
-        for child_name in root_spec.nameChildren:
+        for child_name in root_spec.nameChildren.keys():
             _walk(root.AppendChild(child_name))
 
     return {
@@ -764,13 +764,13 @@ def _inspect_usd_layer(
         if spec:
             authored_prims.append(str(path))
             if hasattr(spec, "nameChildren"):
-                for child_name in spec.nameChildren:
+                for child_name in spec.nameChildren.keys():
                     _walk_layer(path.AppendChild(child_name))
 
     root = Sdf.Path.absoluteRootPath
     root_spec = layer.GetPrimAtPath(root)
     if root_spec and hasattr(root_spec, "nameChildren"):
-        for child_name in root_spec.nameChildren:
+        for child_name in root_spec.nameChildren.keys():
             _walk_layer(root.AppendChild(child_name))
 
     # Sublayers

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/top_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/top_handlers.py
@@ -91,6 +91,17 @@ def _get_graph_context(node: hou.Node):
     parent = node
     while parent is not None:
         if parent.type().category().name() == "TopNet" or parent.type().name() == "topnet":
+            # A TOP network has no PDG node of its own -- it cooks through the
+            # node it displays -- so borrow the context from there. Houdini 22
+            # removed hou.pdg entirely, so the legacy lookup below cannot
+            # resolve anything there and this is the path that works.
+            display = parent.displayNode() if hasattr(parent, "displayNode") else None
+            if display is not None:
+                display_pdg = display.getPDGNode()
+                if display_pdg is not None and display_pdg.context is not None:
+                    return display_pdg.context
+
+            # Legacy path for Houdini versions that still expose hou.pdg.
             try:
                 contexts = hou.pdg.GraphContext.contexts()
                 for ctx in contexts:

--- a/houdini/scripts/python/fxhoudinimcp_server/handlers/top_handlers.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/handlers/top_handlers.py
@@ -39,6 +39,47 @@ def _get_pdg_node(node: hou.Node):
     return pdg_node
 
 
+def _assert_has_generating_node(node: hou.Node) -> None:
+    """Raise unless *node* resolves to a TOP node that produces work items.
+
+    Blocking PDG calls (generateStaticWorkItems(True), cookWorkItems(block=True))
+    run on the main thread here, because the dispatcher marshals every hou.*
+    call through hdefereval. When the target cannot produce work items the
+    blocking call waits on a cook that never starts, and since the main thread
+    is what would advance that cook, Houdini's UI deadlocks and the app has to
+    be force-quit. A freshly created topnet hits this: it contains only a
+    localscheduler, so it is the common case rather than an exotic one.
+
+    Schedulers are the tell -- their PDG object has no ``nodeType``, while
+    Processor/Partitioner/Mapper nodes do.
+    """
+    target = node
+    if node.getPDGNode() is None and hasattr(node, "displayNode"):
+        # TOP networks have no PDG node of their own; they generate through
+        # whichever child is displayed.
+        target = node.displayNode()
+
+    if target is None:
+        raise ValueError(
+            f"TOP network {node.path()} is empty, so there is nothing to "
+            "generate. Add a TOP node (for example wedge or filepattern) first."
+        )
+
+    pdg_node = target.getPDGNode()
+    if pdg_node is None:
+        raise ValueError(
+            f"Node {target.path()} has no PDG node, so it cannot generate "
+            "work items. It may not be a TOP node."
+        )
+
+    if not hasattr(pdg_node, "nodeType"):
+        raise ValueError(
+            f"TOP network {node.path()} contains no work-item-generating "
+            f"nodes -- '{target.name()}' is a scheduler. Add a TOP node "
+            "(for example wedge or filepattern) before generating or cooking."
+        )
+
+
 def _get_graph_context(node: hou.Node):
     """Return the PDG graph context for a TOP node."""
     pdg_node = node.getPDGNode()
@@ -221,6 +262,8 @@ def cook_top_node(
         generate_only: If True, only generate work items without cooking.
     """
     node = _get_top_node(node_path)
+    if block or generate_only:
+        _assert_has_generating_node(node)
 
     if generate_only:
         try:
@@ -490,6 +533,7 @@ def generate_static_items(node_path: str) -> dict:
         node_path: Path to the TOP node.
     """
     node = _get_top_node(node_path)
+    _assert_has_generating_node(node)
 
     try:
         node.generateStaticWorkItems(True)

--- a/python/fxhoudinimcp/bridge.py
+++ b/python/fxhoudinimcp/bridge.py
@@ -54,6 +54,38 @@ class HoudiniBridge:
             self._client = httpx.AsyncClient(timeout=self.timeout)
         return self._client
 
+    async def _reset_client(self) -> httpx.AsyncClient:
+        """Discard the connection pool and return a fresh client."""
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+        self._client = httpx.AsyncClient(timeout=self.timeout)
+        return self._client
+
+    async def _post(
+        self,
+        data: dict[str, Any],
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """POST to the bridge, retrying once past a dead pooled connection.
+
+        Houdini closes its side of the keep-alive connections when it exits,
+        so the first request after a Houdini restart reuses a socket that is
+        already gone and httpx raises RemoteProtocolError. Retrying on a fresh
+        pool reconnects to the new Houdini, instead of leaving this process
+        permanently "disconnected" until the MCP client itself is restarted.
+        """
+        # httpx reads timeout=None as "wait forever", so fall back to the
+        # configured timeout rather than passing None straight through.
+        effective = self.timeout if timeout is None else timeout
+
+        client = await self._get_client()
+        try:
+            return await client.post(self._api_url, data=data, timeout=effective)
+        except httpx.RemoteProtocolError:
+            logger.info("Stale connection to Houdini; reconnecting.")
+            client = await self._reset_client()
+            return await client.post(self._api_url, data=data, timeout=effective)
+
     async def execute(
         self,
         command: str,
@@ -77,12 +109,9 @@ class HoudiniBridge:
         request_id = str(uuid.uuid4())
         logger.info("→ Houdini: %s", command)
 
-        client = await self._get_client()
-
         try:
-            response = await client.post(
-                self._api_url,
-                data=_rpc_body(
+            response = await self._post(
+                _rpc_body(
                     "mcp.execute",
                     command=command,
                     params=params or {},
@@ -91,7 +120,7 @@ class HoudiniBridge:
                 timeout=timeout or self.timeout,
             )
             response.raise_for_status()
-        except httpx.ConnectError as e:
+        except (httpx.ConnectError, httpx.RemoteProtocolError) as e:
             raise ConnectionError(
                 f"Cannot connect to Houdini at {self.base_url}. "
                 "Is Houdini running with the fxhoudinimcp plugin loaded?",
@@ -135,15 +164,15 @@ class HoudiniBridge:
         Returns:
             Dict with houdini_version, hip_file, pid, etc.
         """
-        client = await self._get_client()
         try:
-            response = await client.post(
-                self._api_url,
-                data=_rpc_body("mcp.health"),
-            )
+            response = await self._post(_rpc_body("mcp.health"))
             response.raise_for_status()
             return response.json()
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except (
+            httpx.ConnectError,
+            httpx.RemoteProtocolError,
+            httpx.TimeoutException,
+        ) as e:
             raise ConnectionError(
                 f"Health check failed: cannot reach Houdini at {self.base_url}",
                 details={"original_error": str(e)},


### PR DESCRIPTION
Houdini 22 support, plus two bugs that cost a session when they hit.

Tested against **Houdini FX 22.0.368** (Python 3.13, USD 0.26.5) on macOS by sweeping all 179 registered commands through the live plugin in a GUI session. Every command has at least one run against a valid target. The existing 102 unit tests still pass.

Everything here is verified on 22 specifically — I don't have 20.5/21 to test against, so I've kept the changes backward compatible rather than claiming they're validated there.

Each commit is independent, so feel free to take a subset.

---

### 1. `python3.13libs` so the plugin loads at all

Houdini loads the `pythonX.Ylibs` directory matching its own bundled Python. Houdini 22 ships Python 3.13 and only 3.9-3.11 are present, so nothing matches and `uiready.py` never runs. The failure is silent: no error, no log line, the server simply never comes up on port 8100 and the MCP client reports a connection failure that looks client-side.

`uiready.py` is identical across the shipped version directories, so this is a copy of `python3.11libs`.

### 2. `Sdf.PrimSpec.nameChildren` iteration under USD 0.26.5

Houdini 22 ships USD 0.26.5, where iterating a `PrimSpec`'s `nameChildren` yields **`PrimSpec` objects**; earlier USD yielded name strings. Feeding those to `Sdf.Path.AppendChild` raises:

```
ArgumentError: Python argument types in Path.AppendChild(Path, PrimSpec)
did not match C++ signature: AppendChild(SdfPath {lvalue}, TfToken)
```

This breaks `lops.inspect_usd_layer` and the fallback path of `lops.get_last_modified_prims`.

Iterating `.keys()` yields `str` on both old and new USD, so the fix is backward compatible.

### 3. Blocking PDG calls can deadlock Houdini

**This one hard-freezes the application and requires a force-quit.** It cost me three sessions before I isolated it.

`generateStaticWorkItems(True)` and `cookWorkItems(block=True)` run on the main thread, because `dispatcher.dispatch` marshals every `hou.*` call through `hdefereval.executeInMainThreadWithResult()`. When the target cannot produce work items, the blocking call waits on a cook that never starts — and the main thread is precisely what would advance that cook. The UI stops responding permanently; the process stays alive but has to be killed.

Reproduction on a clean scene:

```
tops.generate_static_items(node_path="/obj/topnet1")   # fresh topnet -> hangs Houdini
```

A freshly created topnet triggers it, because it contains only a `localscheduler` and a TOP network generates through its display node. So "make a topnet, ask for work items" — plausibly a first thing to try — takes out the session.

The guard checks the PDG layer rather than matching type names: a scheduler's PDG object has no `nodeType` attribute, while Processor/Partitioner/Mapper nodes do (`pdg.nodeType` has no `Scheduler` member). Populated networks still generate and cook unchanged; the bad case now returns in ~0.05s with a message naming the scheduler and suggesting adding a TOP node.

Not version-specific — worth having anywhere.

### 4. Reconnect after Houdini restarts

Houdini closes its keep-alive connections on exit, so the first request afterwards reuses a dead socket and httpx raises `RemoteProtocolError`. Nothing caught it, so the server reported *"Server disconnected without sending a response"* and stayed unusable until the MCP client itself was restarted — even though a freshly started server connected to the same Houdini fine.

That asymmetry is the giveaway: restarting Houdini during a session shouldn't require restarting the MCP client.

Fixed by retrying once on a fresh connection pool. Verified by restarting Houdini underneath a live server: it reconnected to the new pid and the next tool call succeeded.

One note while routing `health_check` through the shared helper — `timeout=None` in httpx means *wait forever* rather than "use the client default", so the helper falls back to `self.timeout` to preserve the previous behaviour.

### 5. `hou.pdg` was removed in Houdini 22

`hasattr(hou, "pdg")` is `False` on 22, so the fallback in `_get_graph_context` could never resolve anything: it raised `AttributeError`, which the `except` swallowed, and every lookup ended in *"Cannot find PDG graph context"*.

The visible effect is that `tops.pause_top_cook` and `tops.cancel_top_cook` fail whenever handed a TOP **network**, even though `generate_static_items`, `cook_top_node` and `get_work_item_states` all accept one:

```
tops.pause_top_cook(node_path="/obj/topnet1")         # ValueError: Cannot find PDG graph context
tops.pause_top_cook(node_path="/obj/topnet1/wedge1")  # works
```

A TOP network has no PDG node of its own and cooks through the node it displays, so the context is taken from there. The legacy `hou.pdg` lookup is kept after it for older versions.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
