### PR TITLE
Confirm readiness off the main thread during auto-start

### DIFF
--- a/houdini/MainMenuCommon.xml
+++ b/houdini/MainMenuCommon.xml
@@ -60,6 +60,13 @@ if mcp.is_running():
         f"Status: RUNNING on port {mcp.get_port()}",
         f"Bind address: {os.environ.get('FXHOUDINIMCP_BIND', '127.0.0.1')}",
     ]
+elif mcp.is_starting():
+    # Auto-start confirms readiness on a worker thread, so there is a window
+    # where the server is neither stopped nor confirmed running.
+    lines = [
+        f"Status: STARTING on port {mcp.get_port()}",
+        "Auto-start is still confirming the server answers.",
+    ]
 else:
     lines = [
         "Status: STOPPED",

--- a/houdini/python3.10libs/uiready.py
+++ b/houdini/python3.10libs/uiready.py
@@ -13,6 +13,8 @@ if os.environ.get("FXHOUDINIMCP_AUTOSTART", "1") == "1":
     try:
         import fxhoudinimcp_server.startup
 
-        fxhoudinimcp_server.startup.ensure_running()
+        # wait=False: the readiness poll runs on a worker thread so
+        # Houdini's UI is not blocked while the server comes up.
+        fxhoudinimcp_server.startup.ensure_running(wait=False)
     except Exception as e:
         print(f"[fxhoudinimcp] Auto-start failed: {e}")

--- a/houdini/python3.11libs/uiready.py
+++ b/houdini/python3.11libs/uiready.py
@@ -13,6 +13,8 @@ if os.environ.get("FXHOUDINIMCP_AUTOSTART", "1") == "1":
     try:
         import fxhoudinimcp_server.startup
 
-        fxhoudinimcp_server.startup.ensure_running()
+        # wait=False: the readiness poll runs on a worker thread so
+        # Houdini's UI is not blocked while the server comes up.
+        fxhoudinimcp_server.startup.ensure_running(wait=False)
     except Exception as e:
         print(f"[fxhoudinimcp] Auto-start failed: {e}")

--- a/houdini/python3.13libs/uiready.py
+++ b/houdini/python3.13libs/uiready.py
@@ -13,6 +13,8 @@ if os.environ.get("FXHOUDINIMCP_AUTOSTART", "1") == "1":
     try:
         import fxhoudinimcp_server.startup
 
-        fxhoudinimcp_server.startup.ensure_running()
+        # wait=False: the readiness poll runs on a worker thread so
+        # Houdini's UI is not blocked while the server comes up.
+        fxhoudinimcp_server.startup.ensure_running(wait=False)
     except Exception as e:
         print(f"[fxhoudinimcp] Auto-start failed: {e}")

--- a/houdini/python3.9libs/uiready.py
+++ b/houdini/python3.9libs/uiready.py
@@ -13,6 +13,8 @@ if os.environ.get("FXHOUDINIMCP_AUTOSTART", "1") == "1":
     try:
         import fxhoudinimcp_server.startup
 
-        fxhoudinimcp_server.startup.ensure_running()
+        # wait=False: the readiness poll runs on a worker thread so
+        # Houdini's UI is not blocked while the server comes up.
+        fxhoudinimcp_server.startup.ensure_running(wait=False)
     except Exception as e:
         print(f"[fxhoudinimcp] Auto-start failed: {e}")

--- a/houdini/scripts/python/fxhoudinimcp_server/startup.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/startup.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 # Built-in
 import json
 import os
+import threading
 import time
 import urllib.parse
 import urllib.request
@@ -15,12 +16,15 @@ import urllib.request
 _server_started = False
 _port = 8100
 
-# Ceiling for the readiness poll. This runs on the calling thread -- the main
-# thread during UI auto-start -- so it is a stall budget on genuine failure,
-# not free headroom. A healthy start answers in well under a second, since
-# mcp.health needs nothing from the main thread; the old 3s was tight only
-# because the health endpoint used to deadlock against this very loop.
-_READINESS_TIMEOUT = 10.0
+# True while an auto-start readiness check is still in flight on a worker
+# thread, so a menu click during startup does not start a second server.
+_starting = False
+
+# Ceiling for the readiness poll. A healthy start answers in well under a
+# second, since mcp.health needs nothing from the main thread; the old 3s was
+# tight only because the health endpoint used to deadlock against this very
+# loop. Generous now that auto-start no longer waits on the main thread.
+_READINESS_TIMEOUT = 15.0
 
 
 def _health_url(port: int) -> str:
@@ -94,7 +98,11 @@ def _bind_localhost_only(hwebserver) -> None:
         )
 
 
-def start(port: int | None = None, background: bool | None = None) -> None:
+def start(
+    port: int | None = None,
+    background: bool | None = None,
+    wait: bool = True,
+) -> None:
     """Start the FXHoudini-MCP server.
 
     Registers all command handlers and ensures hwebserver is running.
@@ -111,11 +119,18 @@ def start(port: int | None = None, background: bool | None = None) -> None:
             to Houdini's own choice, which is True in a UI session and False
             under hython. Pass True from a headless script that needs start()
             to return while the server keeps serving.
+        wait: Block until the server answers, and raise if it does not. Pass
+            False for auto-start, where nothing reads the result and blocking
+            would stall Houdini's UI; readiness is then confirmed on a worker
+            thread and failure is printed rather than raised.
     """
-    global _server_started, _port
+    global _server_started, _port, _starting
 
     if _server_started:
         print("[fxhoudinimcp] Server already running")
+        return
+    if _starting:
+        print("[fxhoudinimcp] Server is still starting")
         return
 
     _port = port or int(os.environ.get("FXHOUDINIMCP_PORT", "8100"))
@@ -159,6 +174,33 @@ def start(port: int | None = None, background: bool | None = None) -> None:
             )
         return
 
+    if wait:
+        _confirm_ready(run_error)
+        return
+
+    # Auto-start: nobody is waiting on a return value, so do not make Houdini's
+    # main thread sit through the poll. The worker only does urllib and
+    # os.getpid(), never hou.*, which is safe off the main thread and is exactly
+    # why mcp.health had to become HOM-free.
+    _starting = True
+    worker = threading.Thread(
+        target=_confirm_ready_async, args=(run_error,), daemon=True
+    )
+    try:
+        worker.start()
+    except Exception:
+        # The thread never ran, so nothing else will clear this.
+        _starting = False
+        raise
+
+
+def _confirm_ready(run_error: Exception | None) -> None:
+    """Poll until the server answers as this process, then mark it running.
+
+    Raises on failure, so an explicit Start Server can report why.
+    """
+    global _server_started
+
     health = _wait_for_current_process_health(_port)
     if health is None:
         _server_started = False
@@ -186,6 +228,23 @@ def start(port: int | None = None, background: bool | None = None) -> None:
     )
 
 
+def _confirm_ready_async(run_error: Exception | None) -> None:
+    """_confirm_ready for a daemon thread: reports instead of raising.
+
+    An exception here would die unheard in the worker, so the failure is printed
+    in the same shape auto-start used to raise. _starting is always cleared, or
+    a failed start would leave the server permanently un-startable from the menu.
+    """
+    global _starting
+
+    try:
+        _confirm_ready(run_error)
+    except Exception as exc:
+        print(f"[fxhoudinimcp] Auto-start failed: {exc}")
+    finally:
+        _starting = False
+
+
 def stop() -> None:
     """Stop the FXHoudini-MCP server."""
     global _server_started
@@ -208,12 +267,24 @@ def get_port() -> int:
     return _port
 
 
-def ensure_running() -> None:
-    """Start the server if it's not already running."""
+def is_starting() -> bool:
+    """True while an auto-start readiness check is still in flight."""
+    return _starting
+
+
+def ensure_running(wait: bool = True) -> None:
+    """Start the server if it's not already running.
+
+    Args:
+        wait: Passed through to start(). Auto-start uses False so Houdini's UI
+            is never blocked by the readiness poll.
+    """
     global _server_started
+    if _starting:
+        return
     if _server_started:
         health = _wait_for_current_process_health(_port, timeout_seconds=0.5)
         if health is not None and health.get("pid") == os.getpid():
             return
         _server_started = False
-    start()
+    start(wait=wait)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -20,6 +20,7 @@ from fxhoudinimcp_server import startup  # noqa: E402
 @pytest.fixture(autouse=True)
 def reset_startup_state(monkeypatch):
     monkeypatch.setattr(startup, "_server_started", False)
+    monkeypatch.setattr(startup, "_starting", False)
     monkeypatch.setattr(startup, "_port", 8100)
 
 
@@ -48,11 +49,13 @@ def test_ensure_running_restarts_when_cached_state_is_stale(monkeypatch):
         "_wait_for_current_process_health",
         lambda port, timeout_seconds=0.5: None,
     )
-    monkeypatch.setattr(startup, "start", lambda: calls.append("start"))
+    monkeypatch.setattr(
+        startup, "start", lambda **kw: calls.append(kw)
+    )
 
     startup.ensure_running()
 
-    assert calls == ["start"]
+    assert calls == [{"wait": True}]
 
 
 def test_ensure_running_keeps_live_server(monkeypatch):
@@ -63,8 +66,108 @@ def test_ensure_running_keeps_live_server(monkeypatch):
         "_wait_for_current_process_health",
         lambda port, timeout_seconds=0.5: {"pid": os.getpid()},
     )
-    monkeypatch.setattr(startup, "start", lambda: calls.append("start"))
+    monkeypatch.setattr(
+        startup, "start", lambda **kw: calls.append(kw)
+    )
 
     startup.ensure_running()
 
     assert calls == []
+
+
+###### Off-main-thread readiness (idea from @husman2012, PR #13)
+
+
+def test_ensure_running_passes_wait_through(monkeypatch):
+    """Auto-start must reach start() with wait=False, or the UI still stalls."""
+    calls = []
+    monkeypatch.setattr(startup, "start", lambda **kw: calls.append(kw))
+
+    startup.ensure_running(wait=False)
+
+    assert calls == [{"wait": False}]
+
+
+def test_ensure_running_is_a_noop_while_starting(monkeypatch):
+    calls = []
+    monkeypatch.setattr(startup, "_starting", True)
+    monkeypatch.setattr(startup, "start", lambda **kw: calls.append(kw))
+
+    startup.ensure_running()
+
+    assert calls == []
+
+
+def test_confirm_ready_marks_running(monkeypatch):
+    monkeypatch.setattr(
+        startup,
+        "_wait_for_current_process_health",
+        lambda port: {"pid": os.getpid(), "houdini_version": "22.0.368"},
+    )
+
+    startup._confirm_ready(None)
+
+    assert startup.is_running() is True
+
+
+def test_confirm_ready_raises_when_nothing_answers(monkeypatch):
+    """The synchronous path must raise so Start Server can report why."""
+    monkeypatch.setattr(
+        startup, "_wait_for_current_process_health", lambda port: None
+    )
+
+    with pytest.raises(RuntimeError, match="did not answer"):
+        startup._confirm_ready(None)
+    assert startup.is_running() is False
+
+
+def test_confirm_ready_rejects_another_process(monkeypatch):
+    monkeypatch.setattr(
+        startup,
+        "_wait_for_current_process_health",
+        lambda port: {"pid": os.getpid() + 1},
+    )
+
+    with pytest.raises(RuntimeError, match="owned by another Houdini process"):
+        startup._confirm_ready(None)
+    assert startup.is_running() is False
+
+
+def test_async_confirm_never_raises_and_clears_starting(monkeypatch, capsys):
+    """A worker-thread exception would die unheard, so it must be reported."""
+    monkeypatch.setattr(startup, "_starting", True)
+    monkeypatch.setattr(
+        startup, "_wait_for_current_process_health", lambda port: None
+    )
+
+    startup._confirm_ready_async(None)  # must not raise
+
+    assert startup.is_starting() is False, "a failed start would wedge the menu"
+    assert startup.is_running() is False
+    assert "Auto-start failed" in capsys.readouterr().out
+
+
+def test_async_confirm_clears_starting_on_success(monkeypatch):
+    monkeypatch.setattr(startup, "_starting", True)
+    monkeypatch.setattr(
+        startup,
+        "_wait_for_current_process_health",
+        lambda port: {"pid": os.getpid(), "houdini_version": "22.0.368"},
+    )
+
+    startup._confirm_ready_async(None)
+
+    assert startup.is_starting() is False
+    assert startup.is_running() is True
+
+
+def test_start_declines_while_a_start_is_in_flight(monkeypatch, capsys):
+    """A menu click during auto-start must not start a second server."""
+    monkeypatch.setattr(startup, "_starting", True)
+    startup.start()
+    assert "still starting" in capsys.readouterr().out
+
+
+def test_readiness_timeout_is_generous_now_that_it_is_off_thread():
+    """Off the main thread the ceiling costs nothing, so do not keep it tight."""
+    assert startup._READINESS_TIMEOUT >= 15.0


### PR DESCRIPTION
Adopts @husman2012's approach from #13 ("fix(startup): off-main-thread health-wait -- no more ~10s UI freeze"), which is a better fix than the one that shipped in v2.0.0.

## What v2.0.0 got wrong

Fixing #9 established that `mcp.health` must not touch HOM, because the readiness poll held the main thread while the worker thread needed it. I then cut the main-thread stall from a 3s budget to a 10s one, but left the poll **on the main thread**. So a Houdini whose server never answers still freezes the UI for the whole budget, and I had actually made the worst case longer.

The right move is not to tune the budget, it is to stop blocking the main thread at all.

## Change

Auto-start hands the readiness poll to a daemon thread. `start()` returns in ~45 ms instead of waiting:

```
### wait=False (auto-start path)
  start() returned in 45 ms
  is_starting()=True  is_running()=False
[fxhoudinimcp] Server ready on port 8141 (Houdini 22.0.368, pid 25000)
  after worker: is_starting()=False is_running()=True
  mcp.health -> {"status": "ok", "pid": 25000, "houdini_version": "22.0.368"}
```

This is only safe because `mcp.health` is HOM-free: the worker does urllib and `os.getpid()` and nothing else. The two changes compose, and neither works alone.

`start()` keeps its synchronous behaviour by default, so **MCP > Start Server** still blocks briefly and raises, and the menu can tell the operator why it failed. Only auto-start passes `wait=False`. The split is on "is anyone waiting for an answer" rather than "is there a UI", because a menu click wants the error and a session opening does not.

`_starting` covers the window where the server is neither stopped nor confirmed: a menu click during auto-start declines rather than starting a second server, and **Server Status** reports `STARTING` instead of misreporting `STOPPED`. The worker clears it in a `finally` and prints rather than raising, since an exception on a daemon thread dies unheard and a failed start would otherwise leave the server permanently un-startable from the menu.

Readiness timeout 10s to 15s. Off the main thread the ceiling costs nothing, and @husman2012 independently hit the same cold-start false negative in their "widen cold-start health probe 3s->15s" commit.

## Verification

Against Houdini 22.0.368: `start(wait=False)` returns in 45 ms, the worker confirms, `mcp.health` answers on the port, and the synchronous path still raises on a dead port.

Integration suite green on 20.5.278, 20.5.654, 21.0.440 and 22.0.368 (123 passed, 1 skipped each). Nine new unit tests, 199 total. Ruff output identical to `main` on the changed files.

Credit to @husman2012: the gate work in #13 cannot merge upstream because it hard-depends on the `homedini` package, but this part of it deserved to land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
