### PR TITLE
Find hython under either documented macOS framework layout

### DIFF
--- a/tests/run_integration.py
+++ b/tests/run_integration.py
@@ -49,8 +49,17 @@ def _search_patterns() -> list[str]:
 _HYTHON_SUBPATHS = [
     "bin/hython.exe",
     "bin/hython",
-    # macOS keeps the interpreter inside the framework bundle.
+    # macOS keeps the interpreter inside the framework bundle. SideFX document
+    # both this and a version-numbered directory, so the glob below covers the
+    # case where the Current symlink is absent.
     "Frameworks/Houdini.framework/Versions/Current/Resources/bin/hython",
+]
+
+# Tried after the exact paths above. Houdini's own help documents the macOS
+# location as ".../Houdini.framework/Versions/<version>/Resources/bin", so
+# relying on "Current" alone would miss an install without that symlink.
+_HYTHON_GLOBS = [
+    "Frameworks/Houdini.framework/Versions/*/Resources/bin/hython",
 ]
 
 
@@ -60,10 +69,23 @@ def _version_key(path: Path) -> tuple[int, ...]:
 
 
 def _hython_in(install: Path) -> Path | None:
+    """Find the interpreter inside one install directory.
+
+    Exact paths first because they are the common case and cost one stat each;
+    the globs exist so a layout variation degrades to a slower search rather
+    than to "no Houdini found".
+    """
     for subpath in _HYTHON_SUBPATHS:
         hython = install / subpath
         if hython.is_file():
             return hython
+
+    for pattern in _HYTHON_GLOBS:
+        # Sorted so the choice is deterministic when several versions of the
+        # framework are present inside one install.
+        for hython in sorted(install.glob(pattern)):
+            if hython.is_file():
+                return hython
     return None
 
 

--- a/tests/test_houdini_discovery.py
+++ b/tests/test_houdini_discovery.py
@@ -141,3 +141,56 @@ def test_every_supported_platform_has_a_pattern():
     assert "Side Effects Software" in joined, "no Windows pattern"
     assert "/Applications/Houdini" in joined, "no macOS pattern"
     assert "/opt/hfs" in joined, "no Linux pattern"
+
+
+###### macOS framework layouts
+#
+# Neither of the maintainers has a Mac, so these reproduce the two layouts
+# SideFX's own shipped help documents under ":platform:Mac" rather than relying
+# on an assumption about which one is real:
+#
+#     .../Houdini.framework/Versions/Current/Resources          (x2 in the docs)
+#     .../Houdini.framework/Versions/<version>/Resources/bin     (x1, the Mac bin)
+
+
+def _framework_hython(root: Path, version: str) -> Path:
+    hython = (
+        root
+        / "Houdini20.5.654"
+        / "Frameworks"
+        / "Houdini.framework"
+        / "Versions"
+        / version
+        / "Resources"
+        / "bin"
+        / "hython"
+    )
+    hython.parent.mkdir(parents=True, exist_ok=True)
+    hython.write_text("", encoding="utf-8")
+    return hython
+
+
+def test_macos_current_symlink_layout(isolated):
+    expected = _framework_hython(isolated, "Current")
+    assert find_all_hython() == [expected]
+
+
+def test_macos_version_numbered_layout(isolated):
+    """An install without the Current symlink must still be found."""
+    expected = _framework_hython(isolated, "20.5")
+    assert find_all_hython() == [expected]
+
+
+def test_macos_prefers_current_when_both_exist(isolated):
+    current = _framework_hython(isolated, "Current")
+    _framework_hython(isolated, "20.5")
+    assert find_all_hython() == [current], "the exact path should win over the glob"
+
+
+def test_macos_multiple_framework_versions_pick_deterministically(isolated):
+    """Without Current, several versioned dirs must not order randomly."""
+    _framework_hython(isolated, "20.5")
+    _framework_hython(isolated, "19.5")
+    found = find_all_hython()
+    assert len(found) == 1
+    assert "19.5" in str(found[0]), "expected the sorted-first version"


### PR DESCRIPTION
Neither maintainer has a Mac, so the macOS branch of install discovery has been carrying an untested assumption. Instead of leaving it, I checked it against Houdini's own shipped help, which documents **both** layouts:

```
Houdini.framework/Versions/Current/Resources           (x2)
Houdini.framework/Versions/<version>/Resources/bin     (under :platform:Mac)
```

The code only handled the first. That works while the `Current` symlink exists, and reports "No hython executable found" if it does not, which is the worst failure mode for a discovery function: it looks like Houdini is not installed.

A glob now covers the version-numbered form, tried after the exact paths so the common case still costs a single stat. Glob results are sorted so an install containing several framework versions resolves deterministically rather than by filesystem order.

## What this does and does not prove

Tests reproduce both documented layouts under `tmp_path`, assert the exact path wins over the glob when both are present, and cover the multi-version case. 17 discovery tests total.

It does **not** prove a real macOS install matches SideFX's documentation. What changed is the failure mode: an undocumented layout now degrades to a slower search instead of to nothing found. If anyone with a Mac runs `python tools/gen_node_versions.py` and it finds their install, that closes the loop for good.

Discovery on this machine is unchanged (6 installs found), unit suite 253, integration suite green on 22.0.368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
