### PR TITLE
Let a second Houdini serve, and let the client find it

### DIFF
--- a/houdini/scripts/python/fxhoudinimcp_server/startup.py
+++ b/houdini/scripts/python/fxhoudinimcp_server/startup.py
@@ -26,6 +26,12 @@ _starting = False
 # loop. Generous now that auto-start no longer waits on the main thread.
 _READINESS_TIMEOUT = 15.0
 
+# How many ports to try from the configured base. A second Houdini used to fail
+# outright with "port 8100 is owned by another Houdini process", leaving that
+# session with no MCP at all. Sixteen covers more concurrent sessions than
+# anyone runs while keeping the failed-probe cost bounded.
+_PORT_SEARCH_RANGE = 16
+
 
 def _health_url(port: int) -> str:
     return f"http://127.0.0.1:{port}/api"
@@ -72,6 +78,41 @@ def _wait_for_current_process_health(
                 return health
         time.sleep(0.1)
     return last_health
+
+
+def _pick_free_port(
+    base: int,
+    probe=None,
+    my_pid: int | None = None,
+    max_tries: int = _PORT_SEARCH_RANGE,
+) -> int:
+    """Return the first port at or after *base* this process can serve on.
+
+    A port is free when nothing answers mcp.health there. A port already answering
+    as *this* process is returned as-is, so restarting the server in a session
+    that already has one is idempotent rather than a move to the next port. A
+    port owned by a different pid is another Houdini and is skipped.
+
+    Idea from @husman2012 (PR #13). Note the limitation: "nothing answers
+    mcp.health" is not the same as "nothing holds the socket", so a port occupied
+    by an unrelated server still fails at bind time. That was true before this
+    existed and is reported by the caller either way.
+    """
+    if probe is None:
+        probe = _query_health
+    if my_pid is None:
+        my_pid = os.getpid()
+
+    for port in range(base, base + max_tries):
+        health = probe(port)
+        if health is None:
+            return port
+        if health.get("pid") == my_pid:
+            return port
+    raise RuntimeError(
+        f"No free port in {base}-{base + max_tries - 1}: every one is answering "
+        f"as another Houdini process."
+    )
 
 
 def _bind_localhost_only(hwebserver) -> None:
@@ -133,7 +174,16 @@ def start(
         print("[fxhoudinimcp] Server is still starting")
         return
 
-    _port = port or int(os.environ.get("FXHOUDINIMCP_PORT", "8100"))
+    base = port or int(os.environ.get("FXHOUDINIMCP_PORT", "8100"))
+    _port = _pick_free_port(base)
+    if _port != base:
+        # Say so loudly: the MCP client scans for the port, but anyone who
+        # pinned HOUDINI_PORT on the client side needs to know it moved.
+        print(
+            f"[fxhoudinimcp] Port {base} is already serving another Houdini; "
+            f"using {_port} instead. Set HOUDINI_PORT={_port} on the MCP client "
+            f"if you pin it."
+        )
 
     # Import handlers to trigger registration via register_handler() calls
     from fxhoudinimcp_server import handlers  # noqa: F401

--- a/python/fxhoudinimcp/bridge.py
+++ b/python/fxhoudinimcp/bridge.py
@@ -31,6 +31,42 @@ def _rpc_body(func_name: str, **kwargs: Any) -> dict[str, str]:
     return {"json": json.dumps([func_name, [], kwargs])}
 
 
+# Matches the plugin's own search range: a second Houdini moves itself to the
+# next free port, so the client has to look there rather than assume 8100.
+PORT_SEARCH_RANGE = 16
+
+
+async def find_servers(
+    host: str,
+    base: int,
+    max_tries: int = PORT_SEARCH_RANGE,
+    timeout: float = 1.0,
+) -> list[dict[str, Any]]:
+    """Probe base..base+max_tries for live plugins, lowest port first.
+
+    Each entry is the mcp.health payload plus the port it answered on. Returns
+    every server found rather than just the first, so a caller can say how many
+    Houdini sessions are running instead of silently picking one.
+
+    Probing is cheap because mcp.health touches no HOM: a closed port refuses
+    immediately, and a live one answers without waiting on Houdini's main thread.
+    """
+    found: list[dict[str, Any]] = []
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        for port in range(base, base + max_tries):
+            try:
+                response = await client.post(
+                    f"http://{host}:{port}/api", data=_rpc_body("mcp.health")
+                )
+                response.raise_for_status()
+                payload = response.json()
+            except Exception:
+                continue  # nothing there, or not our endpoint
+            if isinstance(payload, dict) and payload.get("status") == "ok":
+                found.append({**payload, "port": port})
+    return found
+
+
 class HoudiniBridge:
     """Manages HTTP communication between the MCP server and Houdini's hwebserver.
 

--- a/python/fxhoudinimcp/server.py
+++ b/python/fxhoudinimcp/server.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 
 # Internal
-from fxhoudinimcp.bridge import HoudiniBridge
+from fxhoudinimcp.bridge import HoudiniBridge, find_servers
 from fxhoudinimcp.compat import compatibility_warning
 from fxhoudinimcp._loader import load_markdown
 from fxhoudinimcp._version import __version__
@@ -29,7 +29,31 @@ def _get_bridge(ctx) -> HoudiniBridge:
 async def lifespan(server: FastMCP):
     """Manage the Houdini bridge connection lifecycle."""
     host = os.getenv("HOUDINI_HOST", "localhost")
-    port = int(os.getenv("HOUDINI_PORT", "8100"))
+    pinned = os.getenv("HOUDINI_PORT")
+    port = int(pinned) if pinned else 8100
+
+    if not pinned:
+        # A second Houdini moves itself to the next free port, so assuming 8100
+        # would leave that session unreachable. Only scan when the port was not
+        # pinned: an explicit HOUDINI_PORT is a deliberate choice, and silently
+        # connecting somewhere else would be worse than failing.
+        servers = await find_servers(host, port)
+        if servers:
+            port = servers[0]["port"]
+            if len(servers) > 1:
+                others = ", ".join(
+                    f"port {s['port']} (pid {s.get('pid')})" for s in servers[1:]
+                )
+                logger.warning(
+                    "%d Houdini sessions are serving; using port %d (pid %s). "
+                    "Others: %s. Set HOUDINI_PORT to pin a specific one.",
+                    len(servers),
+                    port,
+                    servers[0].get("pid"),
+                    others,
+                )
+            elif port != 8100:
+                logger.info("Found Houdini on port %d", port)
 
     bridge = HoudiniBridge(host=host, port=port)
 
@@ -46,9 +70,8 @@ async def lifespan(server: FastMCP):
         if stale:
             logger.warning(stale)
 
-        # The plugin ships from the repository, not from PyPI, so upgrading the
-        # package does not update it. Name the gap now rather than letting one
-        # tool fail later with what looks like a bug.
+        # Name a plugin/server mismatch now, rather than letting one tool fail
+        # later with what looks like a bug.
         try:
             mismatch = compatibility_warning(await bridge.list_commands())
         except Exception as exc:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 
 # Internal
-from fxhoudinimcp.bridge import HoudiniBridge
+from fxhoudinimcp.bridge import HoudiniBridge, find_servers
 from fxhoudinimcp.errors import ConnectionError, HoudiniCommandError
 
 
@@ -300,3 +300,62 @@ class TestListCommands:
             pytest.raises(ConnectionError),
         ):
             await bridge.list_commands()
+
+
+class TestFindServers:
+    """Client-side discovery: a second Houdini serves on the next free port."""
+
+    def _client(self, answers: dict[int, object]):
+        """A fake client whose reply depends on the port in the URL."""
+        def post(url, **kwargs):
+            port = int(url.rsplit(":", 1)[1].split("/")[0])
+            if port not in answers:
+                raise httpx.ConnectError("refused")
+            resp = MagicMock(spec=httpx.Response)
+            resp.json.return_value = answers[port]
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        client = AsyncMock()
+        client.post = AsyncMock(side_effect=post)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_finds_nothing_when_no_server_answers(self):
+        with patch("httpx.AsyncClient", return_value=self._client({})):
+            assert await find_servers("localhost", 8100, max_tries=3) == []
+
+    @pytest.mark.asyncio
+    async def test_finds_a_single_server(self):
+        answers = {8100: {"status": "ok", "pid": 11}}
+        with patch("httpx.AsyncClient", return_value=self._client(answers)):
+            found = await find_servers("localhost", 8100, max_tries=3)
+        assert [s["port"] for s in found] == [8100]
+        assert found[0]["pid"] == 11
+
+    @pytest.mark.asyncio
+    async def test_finds_every_session_lowest_port_first(self):
+        answers = {
+            8102: {"status": "ok", "pid": 33},
+            8100: {"status": "ok", "pid": 11},
+        }
+        with patch("httpx.AsyncClient", return_value=self._client(answers)):
+            found = await find_servers("localhost", 8100, max_tries=4)
+        assert [s["port"] for s in found] == [8100, 8102]
+
+    @pytest.mark.asyncio
+    async def test_ignores_a_non_plugin_endpoint(self):
+        """Something else on the port must not be mistaken for Houdini."""
+        answers = {8100: {"unrelated": "service"}, 8101: {"status": "ok", "pid": 9}}
+        with patch("httpx.AsyncClient", return_value=self._client(answers)):
+            found = await find_servers("localhost", 8100, max_tries=3)
+        assert [s["port"] for s in found] == [8101]
+
+    @pytest.mark.asyncio
+    async def test_search_range_matches_the_plugin(self):
+        """Client and plugin must agree, or a moved server is unreachable."""
+        from fxhoudinimcp.bridge import PORT_SEARCH_RANGE
+
+        assert PORT_SEARCH_RANGE == 16

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -171,3 +171,53 @@ def test_start_declines_while_a_start_is_in_flight(monkeypatch, capsys):
 def test_readiness_timeout_is_generous_now_that_it_is_off_thread():
     """Off the main thread the ceiling costs nothing, so do not keep it tight."""
     assert startup._READINESS_TIMEOUT >= 15.0
+
+
+###### Concurrent Houdini sessions (idea from @husman2012, PR #13)
+
+
+def test_first_port_is_used_when_free():
+    assert startup._pick_free_port(8100, probe=lambda port: None) == 8100
+
+
+def test_skips_a_port_owned_by_another_houdini():
+    """A second session used to fail outright instead of moving over."""
+    other = {"pid": os.getpid() + 1}
+    probe = lambda port: other if port == 8100 else None  # noqa: E731
+    assert startup._pick_free_port(8100, probe=probe) == 8101
+
+
+def test_skips_several_occupied_ports():
+    other = {"pid": os.getpid() + 1}
+    probe = lambda port: other if port < 8103 else None  # noqa: E731
+    assert startup._pick_free_port(8100, probe=probe) == 8103
+
+
+def test_reuses_a_port_this_process_already_serves():
+    """Restarting in a session that already has a server must not move ports."""
+    mine = {"pid": os.getpid()}
+    probe = lambda port: mine if port == 8100 else None  # noqa: E731
+    assert startup._pick_free_port(8100, probe=probe) == 8100
+
+
+def test_our_own_port_wins_over_moving_on():
+    """Ours at 8101 should be reused, not skipped for a free 8102."""
+    def probe(port):
+        if port == 8100:
+            return {"pid": os.getpid() + 1}
+        if port == 8101:
+            return {"pid": os.getpid()}
+        return None
+
+    assert startup._pick_free_port(8100, probe=probe) == 8101
+
+
+def test_raises_when_every_port_is_taken():
+    other = {"pid": os.getpid() + 1}
+    with pytest.raises(RuntimeError, match="No free port"):
+        startup._pick_free_port(8100, probe=lambda port: other, max_tries=4)
+
+
+def test_search_range_is_bounded():
+    """Each failed probe costs a request, so the range must stay small."""
+    assert 4 <= startup._PORT_SEARCH_RANGE <= 64


### PR DESCRIPTION
Opening a second Houdini left that session with no MCP at all. Reproduced on `main` before the fix:

```
[first]  started, running=True port=8100
[second] FAILED: RuntimeError: hwebserver port 8100 is owned by another
         Houdini process (pid 41116), current pid 29900
```

## Both halves

The port-picking idea is @husman2012's from #13. That PR is closed, and I noted at review time that it only solved the plugin half: a server that relocates to 8101 is useless if the client still assumes 8100. So this adds the discovery half too.

**Plugin**: takes the first free port at or after the configured base, and says so when it moves.

**Client**: probes the same range and connects to what it finds. Cheap precisely because `mcp.health` touches no HOM: a closed port refuses immediately, a live one answers without waiting on Houdini's main thread.

Scanning happens **only when `HOUDINI_PORT` is unset**. An explicit port is a deliberate choice, and silently connecting to a different Houdini than the one asked for would be worse than failing.

## The ambiguity is surfaced, not hidden

With two sessions there is no single right answer, so the lowest port wins and the rest are named with their pids:

```
WARNING 2 Houdini sessions are serving; using port 8100 (pid 42692).
        Others: port 8101 (pid 51164). Set HOUDINI_PORT to pin a specific one.
```

Reusing a port this process already serves is deliberate, so restarting the server in a session that already has one is idempotent rather than walking up the range. Our own port also wins over moving to a free one above it.

## Known limitation, unchanged

"Nothing answers `mcp.health`" is not the same as "nothing holds the socket", so a port occupied by an unrelated server still fails at bind time. That was true before this change and is still reported.

## Verification

Two concurrent Houdini 22.0.368 sessions:

```
[one] started, running=True port=8100
[fxhoudinimcp] Port 8100 is already serving another Houdini; using 8101 instead.
[two] started, running=True port=8101

discovered 2 Houdini session(s):
  port 8100  pid 42692  Houdini 22.0.368
  port 8101  pid 51164  Houdini 22.0.368
port 8100: health pid=42692 commands=179
port 8101: health pid=51164 commands=179
```

12 new unit tests (265 total), integration suite green on 22.0.368, ruff output identical to `main` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
