### PR TITLE
Claim mixed-case node names instead of hiding them

### DIFF
--- a/python/fxhoudinimcp/prompts/markdown/server_instructions.md
+++ b/python/fxhoudinimcp/prompts/markdown/server_instructions.md
@@ -156,7 +156,7 @@ appear here, so use `list_node_types` to see everything actually loaded.
 
 ### Vop (context='Vop')
 
-*   1054 stock types: filter='kma'|'rsl'|'volume'|'mtlx'|'osl'|'mtlxco'|'mtlxdi'|'pxrdis'|'agentc'|'lens' — e.g. kma_aov, rsl_bias, volumegradient, osl_bias, mtlxcombine2, mtlxdielectric_bsdf
+*   1054 stock types: filter='kma'|'rsl'|'volume'|'mtlx'|'osl'|'mtlxco'|'mtlxdi'|'pxrdis'|'agentc'|'lens' — e.g. kma_aov, rsl_bias, volumegradient, mtlxLamaAdd, osl_bias, mtlxcombine2
 
 ### Shop (context='Shop')
 

--- a/tests/integration/test_instruction_accuracy_live.py
+++ b/tests/integration/test_instruction_accuracy_live.py
@@ -113,7 +113,11 @@ def _claimed_names() -> list[tuple[str, str, tuple | None]]:
         tail = re.sub(r"\([^)]*\)", "", tail)
         for chunk in re.split(r"[,—]", tail):
             token = chunk.strip().rstrip(".")
-            if re.fullmatch(r"[a-z][a-z0-9_:.]*[a-z0-9]", token) and (
+            # Internal capitals are allowed: MaterialX node types are spelled
+            # mtlxLamaAdd, and a lowercase-only pattern silently skipped a whole
+            # shading family. Still anchored to a lowercase first character, which
+            # is what keeps prose ("Houdini", "SOP") out.
+            if re.fullmatch(r"[a-z][A-Za-z0-9_:.]*[A-Za-z0-9]", token) and (
                 "_" in token or "::" in token or len(token) >= 4
             ):
                 claims.append((category, token, None))
@@ -176,6 +180,21 @@ def test_every_advertised_node_type_exists():
     assert not missing, (
         f"server_instructions.md advertises {len(missing)} node types that "
         f"do not exist in {hou.applicationVersionString()}: {missing}"
+    )
+
+
+def test_mixed_case_node_names_are_claimed():
+    """A lowercase-only claim pattern silently hid a whole shading family.
+
+    MaterialX VOP types are spelled mtlxLamaAdd. They were being advertised and
+    never checked, and the first fix was to stop advertising them, which threw
+    away useful nodes to satisfy the parser. Guard the parser instead.
+    """
+    claims = {name for _, name, _ in _claimed_names()}
+    mixed = {name for name in claims if any(char.isupper() for char in name)}
+    assert mixed, (
+        "no mixed-case node name is claimed; the pattern has regressed to "
+        "lowercase-only and MaterialX VOPs would go unverified again"
     )
 
 

--- a/tools/gen_node_domains.py
+++ b/tools/gen_node_domains.py
@@ -88,11 +88,12 @@ _MAX_FLAT_NAMES = 24
 _INTERNAL = re.compile(r"^#internal:\s*(\S+)", re.M)
 _CONTEXT = re.compile(r"^#context:\s*(\S+)", re.M)
 
-# Only emit names test_instruction_accuracy_live can actually claim. Its parser
-# requires all-lowercase to avoid mistaking prose for node names, so a name like
-# mtlxLamaAdd would be advertised and silently never verified. Advertising what
-# cannot be checked is exactly what this generator exists to avoid.
-_VERIFIABLE = re.compile(r"[a-z][a-z0-9_:.]*[a-z0-9]$")
+# Only emit names test_instruction_accuracy_live can actually claim, so nothing
+# is advertised without being verified. Its pattern allows internal capitals,
+# because MaterialX types are spelled mtlxLamaAdd and dropping them would hide a
+# whole shading family; it still requires a lowercase first character, which is
+# what keeps prose out.
+_VERIFIABLE = re.compile(r"[a-z][A-Za-z0-9_:.]*[A-Za-z0-9]$")
 
 
 def _verifiable(name: str) -> bool:


### PR DESCRIPTION
`mtlxLamaAdd` is a real MaterialX VOP, and MaterialX is the modern shading path in Solaris and Karma. The accuracy test's claim pattern required all-lowercase, so every `mtlx*` type with internal capitals was advertised to the assistant and **silently never verified**.

My fix in #22 was to stop emitting those names. That was backwards: it discarded a useful shading family to satisfy a limitation in the checker, when the limitation was the bug.

## The change

The claim pattern now allows internal capitals while staying anchored to a lowercase first character, which is what actually keeps prose (`Houdini`, `SOP`) out of the claim set. The generator's filter matches, so `mtlxLamaAdd` is emitted again.

## Verified empirically, not by squinting at the regex

Relaxing the pattern adds exactly one claim:

```
claims: strict 518 -> relaxed 519
newly claimed: Vop/mtlxLamaAdd
```

And the accuracy test still passes on 20.5.278, 20.5.654, 21.0.440 and 22.0.368. That is the check that matters: a prose false positive would fail the existence test immediately, so a green run *is* the proof that the relaxation did not let junk in. Passing on the oldest build also confirms the node exists across the whole supported range.

A regression guard asserts that some mixed-case name is claimed, so a future tightening cannot quietly hide the family again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
