### PR TITLE
One command to install: fxhoudinimcp install

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,33 @@ Uses Houdini's built-in `hwebserver`. No custom socket servers, no rpyc. Uses `h
 - **Python** 3.10+
 - **MCP SDK** (`mcp` package) 1.8+
 
+### Quick start
+
+Two commands, if nothing on your machine is ambiguous:
+
+```shell
+pip install fxhoudinimcp
+fxhoudinimcp install
+```
+
+`install` does both halves: it writes the Houdini package file pointing at this
+exact install, and registers the server with Claude Code and Claude Desktop
+using the absolute path of the Python you installed into. Add `--dry-run` to see
+what it would touch without changing anything.
+
+It stops and asks when it cannot know the answer. If several Houdini packages
+directories exist, it lists them rather than guessing, because guessing wrongly
+produces an install that fails silently:
+
+```shell
+fxhoudinimcp install --houdini-dir "~/Documents/houdini22.0/packages"
+```
+
+Other flags: `--client claude-code|claude-desktop|both|none` to control which
+client is touched, `none` if you wire it up yourself.
+
+The step-by-step version follows, for when something needs untangling.
+
 ### 1. Install the MCP Server
 
 **From PyPI:**
@@ -168,6 +195,9 @@ Since **2.1.0** the plugin ships inside the Python package, so `pip install
 distributed separately and it was easy to upgrade one and leave the other
 behind; the server now warns at startup when it finds a plugin older than
 itself.
+
+`fxhoudinimcp install` (above) does this step for you. The rest of this section
+is the manual route.
 
 **Option A: let the CLI write the package file (recommended)**
 
@@ -314,7 +344,12 @@ Or to scope it to a single project, add a `.mcp.json` in the project root:
 <!-- USAGE -->
 ## Usage
 
-Launch Houdini normally. The plugin auto-starts once when the UI is ready (controlled by `FXHOUDINIMCP_AUTOSTART` env var). The startup script uses `uiready.py`, which stacks correctly with other Houdini packages. You can also control it manually from the **MCP** menu (Start Server, Stop Server, Server Status).
+Launch Houdini normally. The plugin auto-starts once when the UI is ready (controlled by `FXHOUDINIMCP_AUTOSTART` env var). The startup script uses `uiready.py`, which stacks correctly with other Houdini packages. You can also control it manually from the **MCP** menu (Start Server, Stop Server, Connect a Client, Server Status).
+
+**MCP > Connect a Client...** prints the `claude mcp add` line for the port this
+session actually ended up on, and copies it to the clipboard. That matters with
+more than one Houdini open: a second session moves itself to the next free port,
+so the configured port and the real one differ.
 
 Startup verifies that Houdini's `mcp.health` endpoint answers from the current
 Houdini process before printing that the server is ready. If your assistant

--- a/houdini/MainMenuCommon.xml
+++ b/houdini/MainMenuCommon.xml
@@ -47,6 +47,82 @@ else:
 
       <separatorItem/>
 
+      <scriptItem id="fxhoudinimcp_connect">
+        <label>Connect a Client...</label>
+        <scriptCode><![CDATA[
+import hou
+import fxhoudinimcp_server.startup as mcp
+
+# The port the server actually ended up on, which is not always the configured
+# one: a second Houdini moves itself to the next free port. Printing the
+# configured port here would hand out a command pointing at the wrong session.
+port = mcp.get_port()
+
+# A bare "python" on purpose. From inside Houdini, sys.executable is Houdini's
+# own interpreter, not the external Python that has fxhoudinimcp installed, and
+# this side has no reliable way to find that one. Since clients are launched
+# without the user's shell environment, a bare name can resolve against a PATH
+# that lacks the right Python, showing up only as "disconnected" -- which is
+# exactly why the message points at `fxhoudinimcp install`, where sys.executable
+# *is* the right answer.
+command = "python -m fxhoudinimcp"
+
+lines = [
+    "Register this Houdini session with an MCP client.",
+    "",
+    "Claude Code:",
+    f"    claude mcp add --scope user fxhoudini -- {command}",
+]
+
+if port != 8100:
+    lines += [
+        "",
+        f"This session is on port {port}, not the default 8100, because another",
+        "Houdini was already serving. The client scans 8100-8115 and picks the",
+        f"lowest, so pin this one with HOUDINI_PORT={port} if you want it",
+        "specifically.",
+    ]
+else:
+    lines += [
+        "",
+        f"Serving on port {port}. The client finds this automatically.",
+    ]
+
+if not mcp.is_running():
+    lines += [
+        "",
+        "NOTE: the server is not running yet. Use MCP > Start Server first,",
+        "or the client will have nothing to connect to.",
+    ]
+
+lines += [
+    "",
+    "Easier: 'fxhoudinimcp install' does the client registration for you,",
+    "with the absolute Python path filled in.",
+]
+
+text = "\n".join(lines)
+copied = False
+try:
+    hou.ui.copyTextToClipboard(
+        f"claude mcp add --scope user fxhoudini -- {command}"
+    )
+    copied = True
+except Exception:
+    # Deliberately broad. There is no clipboard on a headless or remote display,
+    # and the exact exception is not worth guessing: failing to copy must never
+    # stop the command being shown, which is the part that matters.
+    pass
+
+if copied:
+    text += "\n\n(The Claude Code command is on your clipboard.)"
+
+hou.ui.displayMessage(text, title="FXHoudini-MCP: Connect a Client")
+]]></scriptCode>
+      </scriptItem>
+
+      <separatorItem/>
+
       <scriptItem id="fxhoudinimcp_status">
         <label>Server Status...</label>
         <scriptCode><![CDATA[

--- a/python/fxhoudinimcp/__main__.py
+++ b/python/fxhoudinimcp/__main__.py
@@ -9,13 +9,18 @@ import sys
 
 
 def main() -> None:
-    # A single subcommand, handled before the MCP plumbing loads: the server is
+    # Subcommands are handled before the MCP plumbing loads: the server is
     # normally launched by an MCP client with no arguments, so argparse-ing the
     # whole entry point would risk changing that contract.
     if len(sys.argv) > 1 and sys.argv[1] == "houdini-package":
         from fxhoudinimcp.houdini_package import main as houdini_package_main
 
         raise SystemExit(houdini_package_main(sys.argv[2:]))
+
+    if len(sys.argv) > 1 and sys.argv[1] == "install":
+        from fxhoudinimcp.install import main as install_main
+
+        raise SystemExit(install_main(sys.argv[2:]))
 
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     logging.basicConfig(level=getattr(logging, log_level, logging.INFO))

--- a/python/fxhoudinimcp/houdini_package.py
+++ b/python/fxhoudinimcp/houdini_package.py
@@ -121,6 +121,24 @@ def existing_packages(exclude: Path | None = None) -> list[tuple[Path, str]]:
     return found
 
 
+def write_package(destination: Path, path: Path | None = None) -> Path:
+    """Write ``fxhoudinimcp.json`` into *destination* and return the file written.
+
+    Shared with ``fxhoudinimcp install`` so there is one place that knows the
+    encoding rules. utf-8 *without* a BOM: Houdini's JSON parser rejects a BOM
+    and skips the whole package silently, which is the trap behind issue #11.
+
+    Raises NotADirectoryError if *destination* does not exist, rather than
+    creating it: a typo'd path would otherwise produce a package file in a
+    directory Houdini never reads, and Houdini reports nothing when that happens.
+    """
+    if not destination.is_dir():
+        raise NotADirectoryError(destination)
+    target = destination / _PACKAGE_NAME
+    target.write_text(package_json(path), encoding="utf-8", newline="\n")
+    return target
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="fxhoudinimcp houdini-package",
@@ -157,7 +175,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.write:
         destination = Path(args.write).expanduser()
-        if not destination.is_dir():
+        try:
+            target = write_package(destination, plugin)
+        except NotADirectoryError:
             print(
                 f"Not a directory: {destination}\n"
                 "Create it first, or pick one of the candidates listed by "
@@ -165,10 +185,6 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
             return 1
-        target = destination / _PACKAGE_NAME
-        # utf-8 without a BOM: Houdini's JSON parser rejects a BOM and skips the
-        # whole package, which is the trap documented in issue #11.
-        target.write_text(contents, encoding="utf-8", newline="\n")
         print(f"Wrote {target}")
 
         others = existing_packages(exclude=target)

--- a/python/fxhoudinimcp/install.py
+++ b/python/fxhoudinimcp/install.py
@@ -1,0 +1,373 @@
+"""One command that wires up both halves.
+
+Installing used to be four steps across two worlds: pip install, work out which
+Houdini packages directory is the real one, write a JSON file there, then hand
+your MCP client a command line whose Python path you had to discover yourself.
+Every one of those steps fails quietly. Houdini skips a package file it cannot
+resolve without saying so, and Claude Desktop does not inherit your PATH, so a
+bare ``python`` in its config reads as "disconnected" with no explanation.
+
+    fxhoudinimcp install                      # do both halves
+    fxhoudinimcp install --dry-run            # say what it would do, change nothing
+    fxhoudinimcp install --houdini-dir DIR    # when the packages directory is ambiguous
+    fxhoudinimcp install --client none        # plugin only, wire the client yourself
+
+The Houdini destination is still not guessed when it is genuinely ambiguous. One
+candidate means there is nothing to choose and it is used; several means the
+operator picks, because choosing wrongly on Windows with OneDrive's Documents
+redirection recreates the silent no-op this command exists to prevent.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Internal
+from fxhoudinimcp.houdini_package import (
+    candidate_package_dirs,
+    existing_packages,
+    plugin_path,
+    write_package,
+)
+
+# The name the server is registered under with MCP clients.
+SERVER_NAME = "fxhoudini"
+
+
+def client_command() -> list[str]:
+    """The argv an MCP client should run to start this server.
+
+    sys.executable, never a bare "python". Claude Desktop launches its servers
+    without the user's shell environment, so a bare interpreter name resolves
+    against a PATH that may not contain the Python this package is installed
+    into. That failure surfaces only as "disconnected", which is why the README
+    had to explain it; an absolute path removes the class of problem.
+    """
+    return [sys.executable, "-m", "fxhoudinimcp"]
+
+
+def desktop_config_path() -> Path | None:
+    """Claude Desktop's config file for this platform, whether or not it exists."""
+    system = platform.system()
+    if system == "Windows":
+        base = os.environ.get("APPDATA")
+        if not base:
+            return None
+        return Path(base) / "Claude" / "claude_desktop_config.json"
+    if system == "Darwin":
+        return (
+            Path.home()
+            / "Library"
+            / "Application Support"
+            / "Claude"
+            / "claude_desktop_config.json"
+        )
+    return Path.home() / ".config" / "Claude" / "claude_desktop_config.json"
+
+
+def claude_code_available() -> bool:
+    return shutil.which("claude") is not None
+
+
+def claude_code_add_argv(scope: str = "user") -> list[str]:
+    """The `claude mcp add` invocation, for running or for printing verbatim."""
+    return [
+        "claude",
+        "mcp",
+        "add",
+        "--scope",
+        scope,
+        SERVER_NAME,
+        "--",
+        *client_command(),
+    ]
+
+
+def resolve_houdini_dir(explicit: str | None) -> tuple[Path | None, list[Path], str]:
+    """Decide where the package file goes.
+
+    Returns (chosen, candidates, reason). *chosen* is None when the operator has
+    to decide, with *reason* explaining why rather than making it up.
+    """
+    if explicit:
+        return Path(explicit).expanduser(), [], "given on the command line"
+
+    candidates = candidate_package_dirs()
+    if not candidates:
+        return None, [], "no Houdini packages directory exists yet"
+    if len(candidates) == 1:
+        return candidates[0], candidates, "the only candidate on this machine"
+    return None, candidates, f"{len(candidates)} candidates, so the choice is yours"
+
+
+def _merge_desktop_config(existing: dict, command: list[str]) -> dict:
+    """Point our entry at *command* while preserving everything else.
+
+    Someone's Desktop config is likely to hold servers that took effort to set
+    up, so this merges rather than writing a fresh document, and never reorders
+    or drops what it does not understand.
+
+    That care has to extend inside our own entry, not just around it. Replacing
+    the whole entry looked correct until it met a real config, which carried an
+    ``env`` block with HOUDINI_HOST and HOUDINI_PORT: rewriting the entry
+    wholesale would have deleted the user's settings while reporting success.
+    Only ``command`` and ``args`` are ours to set.
+    """
+    merged = dict(existing)
+    servers = dict(merged.get("mcpServers") or {})
+    entry = dict(servers.get(SERVER_NAME) or {})
+    entry["command"] = command[0]
+    entry["args"] = list(command[1:])
+    servers[SERVER_NAME] = entry
+    merged["mcpServers"] = servers
+    return merged
+
+
+def pinned_port_warning(entry: dict | None) -> list[str]:
+    """Warn when a config pins HOUDINI_PORT, which disables port discovery.
+
+    An explicit HOUDINI_PORT is honoured deliberately by the server: it means
+    "this session, not whichever answers first". But it also switches off the
+    scan of 8100-8115, so a second Houdini that moved itself to 8101 becomes
+    unreachable. Worth saying out loud, since the value is usually left over
+    from an older config rather than chosen.
+    """
+    port = ((entry or {}).get("env") or {}).get("HOUDINI_PORT")
+    if not port:
+        return []
+    return [
+        f"  NOTE: this entry pins HOUDINI_PORT={port}, so the client will not scan",
+        "        for other Houdini sessions. A second Houdini moves itself to the",
+        "        next free port and would be unreachable. Remove it from 'env' to",
+        "        let the client find whichever session is serving.",
+    ]
+
+
+def install_desktop(config: Path, command: list[str], dry_run: bool) -> list[str]:
+    """Register the server in Claude Desktop's config. Returns report lines."""
+    lines: list[str] = []
+    existing: dict = {}
+    if config.is_file():
+        try:
+            existing = json.loads(config.read_text(encoding="utf-8-sig")) or {}
+        except Exception as exc:
+            return [
+                f"  SKIPPED Claude Desktop: {config} is not readable JSON ({exc}).",
+                "          Fix or remove it, then re-run. It was left untouched.",
+            ]
+        if not isinstance(existing, dict):
+            return [
+                f"  SKIPPED Claude Desktop: {config} is not a JSON object.",
+                "          It was left untouched.",
+            ]
+
+    already = (existing.get("mcpServers") or {}).get(SERVER_NAME)
+    merged = _merge_desktop_config(existing, command)
+    if already == merged["mcpServers"][SERVER_NAME]:
+        return [
+            f"  Claude Desktop already points at this install ({config}).",
+            *pinned_port_warning(already),
+        ]
+
+    if dry_run:
+        lines.append(f"  Would update {config}")
+        if already is not None:
+            old = already.get("command")
+            lines.append(
+                f"          repointing command from {old!r} to {command[0]!r}"
+            )
+            lines.append("          keeping every other key in the entry")
+        lines += pinned_port_warning(already)
+        return lines
+
+    config.parent.mkdir(parents=True, exist_ok=True)
+    if config.is_file():
+        # Keep a copy. This file can hold hand-built server entries, and an
+        # installer that eats them is worse than one that never ran.
+        backup = config.with_suffix(config.suffix + ".bak")
+        shutil.copy2(config, backup)
+        lines.append(f"  Backed up {backup.name}")
+    config.write_text(
+        json.dumps(merged, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
+    lines.append(f"  Registered '{SERVER_NAME}' in {config}")
+    lines += pinned_port_warning(already)
+    lines.append("  Fully quit Claude Desktop (tray > Quit) and relaunch.")
+    return lines
+
+
+def install_claude_code(dry_run: bool) -> list[str]:
+    """Register with Claude Code via its own CLI. Returns report lines."""
+    argv = claude_code_add_argv()
+    printable = " ".join(f'"{part}"' if " " in part else part for part in argv)
+
+    if not claude_code_available():
+        return [
+            "  Claude Code CLI not on PATH, so nothing was changed. Run this",
+            "  yourself if you use Claude Code:",
+            f"      {printable}",
+        ]
+    if dry_run:
+        return [f"  Would run: {printable}"]
+
+    # Its own CLI owns the config schema, so shell out rather than editing
+    # ~/.claude.json directly and risking a shape this version does not expect.
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode == 0:
+        return [f"  Registered '{SERVER_NAME}' with Claude Code (user scope)."]
+    detail = (result.stderr or result.stdout or "").strip().splitlines()
+    first = detail[0] if detail else f"exit code {result.returncode}"
+    return [
+        f"  Claude Code registration failed: {first}",
+        "  Already added under this name? Remove it first:",
+        f"      claude mcp remove {SERVER_NAME}",
+        f"  Or run it yourself: {printable}",
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="fxhoudinimcp install",
+        description="Install the Houdini plugin and register this server "
+        "with your MCP client.",
+    )
+    parser.add_argument(
+        "--houdini-dir",
+        metavar="DIR",
+        help="Houdini packages directory to write into (required only when "
+        "several candidates exist)",
+    )
+    parser.add_argument(
+        "--client",
+        choices=("auto", "claude-code", "claude-desktop", "both", "none"),
+        default="auto",
+        help="which MCP client to register with (default: auto, meaning "
+        "whichever of the two is present)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would change without changing anything",
+    )
+    args = parser.parse_args(argv)
+
+    plugin = plugin_path()
+    if not plugin.is_dir():
+        print(
+            f"The plugin directory is missing: {plugin}\n"
+            "This install predates the plugin shipping inside the package "
+            "(2.1.0), or came from a source tree without it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    prefix = "Would install" if args.dry_run else "Installing"
+    print(f"{prefix} FXHoudini-MCP")
+    print(f"  Python : {sys.executable}")
+    print(f"  Plugin : {plugin.as_posix()}")
+    print()
+
+    # -- Half one: the Houdini plugin
+    chosen, candidates, reason = resolve_houdini_dir(args.houdini_dir)
+    print("Houdini plugin")
+    if chosen is None:
+        if candidates:
+            print(f"  Cannot choose for you: {reason}.")
+            for candidate in candidates:
+                print(f"      {candidate}")
+            print("\n  Re-run with the one your Houdini actually reads:")
+            print(f'      fxhoudinimcp install --houdini-dir "{candidates[0]}"')
+            print(
+                "\n  On Windows with OneDrive redirecting Documents, a "
+                "desktop-launched\n  Houdini and a shell-launched one can "
+                "disagree. Start Houdini with\n  HOUDINI_PACKAGE_VERBOSE=1 to "
+                "see which it reads."
+            )
+        else:
+            print(f"  {reason.capitalize()}.")
+            print(
+                "  Create one inside your Houdini preferences directory, for "
+                "example\n      Documents/houdini22.0/packages\n"
+                "  then re-run this command."
+            )
+        return 1
+
+    if args.dry_run:
+        print(f"  Would write fxhoudinimcp.json into {chosen} ({reason})")
+    else:
+        try:
+            written = write_package(chosen, plugin)
+        except NotADirectoryError:
+            print(f"  Not a directory: {chosen}", file=sys.stderr)
+            print(
+                "  Create it first, or pass a different --houdini-dir.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"  Wrote {written} ({reason})")
+
+    others = existing_packages(exclude=chosen / "fxhoudinimcp.json")
+    if others:
+        print(
+            f"\n  WARNING: {len(others)} other fxhoudinimcp.json exists. Houdini "
+            "processes every\n  packages directory and the last one wins, so a "
+            "leftover file can silently\n  override this install:"
+        )
+        for path, points_at in others:
+            print(f"      {path}\n          -> {points_at}")
+        print("  Delete the ones you do not want.")
+
+    # -- Half two: the MCP client
+    print("\nMCP client")
+    wanted = args.client
+    if wanted == "auto":
+        targets = []
+        if claude_code_available():
+            targets.append("claude-code")
+        config = desktop_config_path()
+        if config is not None and config.parent.is_dir():
+            targets.append("claude-desktop")
+        if not targets:
+            print("  Neither Claude Code nor Claude Desktop was detected.")
+            printable = " ".join(claude_code_add_argv())
+            print(f"  For Claude Code:  {printable}")
+            print(f"  For anything else, run: {' '.join(client_command())}")
+            targets = []
+    elif wanted == "both":
+        targets = ["claude-code", "claude-desktop"]
+    elif wanted == "none":
+        print("  Skipped (--client none). Start the server with:")
+        print(f"      {' '.join(client_command())}")
+        targets = []
+    else:
+        targets = [wanted]
+
+    for target in targets:
+        if target == "claude-code":
+            for line in install_claude_code(args.dry_run):
+                print(line)
+        else:
+            config = desktop_config_path()
+            if config is None:
+                print("  Could not locate Claude Desktop's config on this platform.")
+                continue
+            for line in install_desktop(config, client_command(), args.dry_run):
+                print(line)
+
+    if args.dry_run:
+        print("\nNothing was changed (--dry-run).")
+    else:
+        print("\nRestart Houdini, then check the MCP menu.")
+        print(
+            "MCP > Connect a Client... prints the command again, with the port "
+            "the\nserver actually ended up on."
+        )
+    return 0

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,335 @@
+"""Tests for the one-shot installer.
+
+This command writes to two places that matter to someone else: a Houdini
+packages directory, and an MCP client's config. Both have a failure mode worse
+than not running at all, so the tests concentrate on what it must never do --
+guess an ambiguous Houdini directory, or damage a config full of other people's
+servers.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Third-party
+import pytest
+
+# Internal
+from fxhoudinimcp import install as inst
+
+
+def _entry(config: dict) -> dict:
+    """Our server's entry out of a merged config."""
+    return config["mcpServers"][inst.SERVER_NAME]
+
+
+@pytest.fixture
+def plugin_dir(tmp_path, monkeypatch):
+    """A plugin directory that exists, so main() gets past its first guard."""
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    monkeypatch.setattr(inst, "plugin_path", lambda: plugin)
+    return plugin
+
+
+@pytest.fixture
+def isolated(monkeypatch):
+    """Keep the real machine out of the test: no Houdini dirs, no clients."""
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [])
+    monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
+
+
+###### The command an MCP client is told to run
+
+
+def test_client_command_uses_absolute_interpreter():
+    """A bare "python" is the documented cause of "disconnected" in Desktop.
+
+    Clients start their servers without the user's shell environment, so the
+    interpreter must be spelled out rather than resolved against PATH.
+    """
+    command = inst.client_command()
+    assert command[0] == sys.executable
+    assert Path(command[0]).is_absolute()
+    assert command[1:] == ["-m", "fxhoudinimcp"]
+
+
+def test_claude_code_argv_separates_options_from_command():
+    """Everything after `--` is passed to the server untouched.
+
+    Without the separator, Claude Code would read the interpreter path as one of
+    its own arguments.
+    """
+    argv = inst.claude_code_add_argv()
+    assert argv[:3] == ["claude", "mcp", "add"]
+    separator = argv.index("--")
+    assert argv[separator - 1] == inst.SERVER_NAME
+    assert argv[separator + 1 :] == inst.client_command()
+
+
+###### Choosing the Houdini packages directory
+
+
+def test_explicit_dir_wins(monkeypatch):
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [Path("/ignored")])
+    chosen, _, _ = inst.resolve_houdini_dir("~/somewhere")
+    assert chosen == Path("~/somewhere").expanduser()
+
+
+def test_single_candidate_is_used(monkeypatch, tmp_path):
+    """One candidate means there is nothing to choose, so do not make the user."""
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [tmp_path])
+    chosen, candidates, _ = inst.resolve_houdini_dir(None)
+    assert chosen == tmp_path
+    assert candidates == [tmp_path]
+
+
+def test_several_candidates_refuse_to_guess(monkeypatch, tmp_path):
+    """The OneDrive redirection case. Guessing recreates a silent no-op.
+
+    A desktop-launched Houdini and a shell-launched one can resolve different
+    preference directories on Windows, and Houdini reports nothing when it skips
+    a package file, so the wrong guess is invisible.
+    """
+    first, second = tmp_path / "a", tmp_path / "b"
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [first, second])
+    chosen, candidates, reason = inst.resolve_houdini_dir(None)
+    assert chosen is None
+    assert candidates == [first, second]
+    assert "2 candidates" in reason
+
+
+def test_ambiguous_dir_exits_nonzero_and_writes_nothing(
+    plugin_dir, tmp_path, monkeypatch, capsys
+):
+    first, second = tmp_path / "a", tmp_path / "b"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [first, second])
+    monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
+
+    assert inst.main([]) == 1
+    assert not list(first.iterdir())
+    assert not list(second.iterdir())
+    assert "Cannot choose for you" in capsys.readouterr().out
+
+
+def test_writes_package_into_chosen_dir(plugin_dir, isolated, tmp_path, capsys):
+    packages = tmp_path / "packages"
+    packages.mkdir()
+
+    assert inst.main(["--houdini-dir", str(packages), "--client", "none"]) == 0
+
+    written = packages / "fxhoudinimcp.json"
+    data = json.loads(written.read_text(encoding="utf-8"))
+    assert data["env"][0]["FXHOUDINIMCP"] == plugin_dir.as_posix()
+    assert "Restart Houdini" in capsys.readouterr().out
+
+
+def test_dry_run_changes_nothing(plugin_dir, isolated, tmp_path, capsys):
+    packages = tmp_path / "packages"
+    packages.mkdir()
+
+    assert inst.main(["--houdini-dir", str(packages), "--dry-run"]) == 0
+
+    assert not list(packages.iterdir())
+    assert "Nothing was changed" in capsys.readouterr().out
+
+
+def test_missing_plugin_is_reported(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(inst, "plugin_path", lambda: tmp_path / "absent")
+    assert inst.main([]) == 1
+    assert "plugin directory is missing" in capsys.readouterr().err
+
+
+###### Claude Desktop config
+
+
+def test_desktop_merge_preserves_other_servers():
+    """Someone's config is likely to hold servers that took effort to set up."""
+    existing = {
+        "mcpServers": {"other": {"command": "node", "args": ["x.js"]}},
+        "someUnrelatedKey": {"keep": True},
+    }
+    merged = inst._merge_desktop_config(existing, ["/py", "-m", "fxhoudinimcp"])
+
+    assert merged["mcpServers"]["other"] == {"command": "node", "args": ["x.js"]}
+    assert merged["someUnrelatedKey"] == {"keep": True}
+    assert merged["mcpServers"][inst.SERVER_NAME] == {
+        "command": "/py",
+        "args": ["-m", "fxhoudinimcp"],
+    }
+
+
+def test_desktop_merge_preserves_env_inside_our_own_entry():
+    """The bug a real config caught: rewriting our entry ate the user's env.
+
+    A live Claude Desktop config had an ``env`` block with HOUDINI_HOST and
+    HOUDINI_PORT. Replacing the whole entry deleted those while reporting
+    success, which is worse than failing.
+    """
+    existing = {
+        "mcpServers": {
+            inst.SERVER_NAME: {
+                "command": "python",
+                "args": ["-m", "fxhoudinimcp"],
+                "env": {"HOUDINI_HOST": "localhost", "HOUDINI_PORT": "8100"},
+            }
+        }
+    }
+    merged = _entry(inst._merge_desktop_config(existing, ["/abs/py", "-m", "x"]))
+
+    assert merged["env"] == {"HOUDINI_HOST": "localhost", "HOUDINI_PORT": "8100"}
+    assert merged["command"] == "/abs/py"
+    assert merged["args"] == ["-m", "x"]
+
+
+def test_desktop_install_keeps_env_on_disk(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    inst.SERVER_NAME: {
+                        "command": "python",
+                        "args": ["-m", "fxhoudinimcp"],
+                        "env": {"HOUDINI_PORT": "8100"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    inst.install_desktop(config, ["/abs/py", "-m", "fxhoudinimcp"], dry_run=False)
+
+    entry = json.loads(config.read_text(encoding="utf-8"))["mcpServers"][
+        inst.SERVER_NAME
+    ]
+    assert entry["env"] == {"HOUDINI_PORT": "8100"}
+    assert entry["command"] == "/abs/py"
+
+
+def test_pinned_port_is_reported():
+    """Pinning HOUDINI_PORT silently disables the multi-session port scan."""
+    warning = inst.pinned_port_warning(
+        {"command": "python", "env": {"HOUDINI_PORT": "8100"}}
+    )
+    assert warning
+    assert any("8100" in line for line in warning)
+    assert any("second Houdini" in line for line in warning)
+
+
+def test_no_pinned_port_no_warning():
+    assert inst.pinned_port_warning({"command": "python"}) == []
+    assert inst.pinned_port_warning(None) == []
+
+
+def test_desktop_merge_does_not_mutate_input():
+    existing = {"mcpServers": {"other": {}}}
+    inst._merge_desktop_config(existing, ["/py", "-m", "fxhoudinimcp"])
+    assert existing == {"mcpServers": {"other": {}}}
+
+
+def test_desktop_install_backs_up_before_writing(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    original = {"mcpServers": {"other": {"command": "node"}}}
+    config.write_text(json.dumps(original), encoding="utf-8")
+
+    inst.install_desktop(config, ["/py", "-m", "fxhoudinimcp"], dry_run=False)
+
+    backup = config.with_suffix(config.suffix + ".bak")
+    assert json.loads(backup.read_text(encoding="utf-8")) == original
+    written = json.loads(config.read_text(encoding="utf-8"))
+    assert "other" in written["mcpServers"]
+    assert inst.SERVER_NAME in written["mcpServers"]
+
+
+def test_desktop_install_creates_missing_config(tmp_path):
+    config = tmp_path / "nested" / "claude_desktop_config.json"
+    inst.install_desktop(config, ["/py", "-m", "fxhoudinimcp"], dry_run=False)
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert data["mcpServers"][inst.SERVER_NAME]["command"] == "/py"
+
+
+def test_desktop_install_leaves_unparseable_config_alone(tmp_path):
+    """Better to refuse than to overwrite a file we cannot understand."""
+    config = tmp_path / "claude_desktop_config.json"
+    config.write_text("{ this is not json", encoding="utf-8")
+
+    lines = inst.install_desktop(config, ["/py", "-m", "fxhoudinimcp"], dry_run=False)
+
+    assert config.read_text(encoding="utf-8") == "{ this is not json"
+    assert not config.with_suffix(config.suffix + ".bak").exists()
+    assert any("SKIPPED" in line for line in lines)
+
+
+def test_desktop_install_is_idempotent(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    command = ["/py", "-m", "fxhoudinimcp"]
+    inst.install_desktop(config, command, dry_run=False)
+    first = config.read_text(encoding="utf-8")
+
+    lines = inst.install_desktop(config, command, dry_run=False)
+
+    assert config.read_text(encoding="utf-8") == first
+    assert any("already points at this install" in line for line in lines)
+
+
+def test_desktop_dry_run_writes_nothing(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    lines = inst.install_desktop(config, ["/py", "-m", "fxhoudinimcp"], dry_run=True)
+    assert not config.exists()
+    assert any("Would update" in line for line in lines)
+
+
+###### Claude Code registration
+
+
+def test_claude_code_missing_prints_the_command(monkeypatch):
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    lines = inst.install_claude_code(dry_run=False)
+    assert any("claude mcp add" in line for line in lines)
+
+
+def test_claude_code_failure_is_explained(monkeypatch):
+    """A duplicate name is the likely failure, so name the way out of it."""
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(
+            argv, 1, stdout="", stderr="server already exists"
+        )
+
+    monkeypatch.setattr(inst.subprocess, "run", fake_run)
+    lines = inst.install_claude_code(dry_run=False)
+    assert any("already exists" in line for line in lines)
+    assert any(f"claude mcp remove {inst.SERVER_NAME}" in line for line in lines)
+
+
+def test_claude_code_dry_run_does_not_shell_out(monkeypatch):
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+
+    def explode(*args, **kwargs):
+        raise AssertionError("--dry-run must not run the CLI")
+
+    monkeypatch.setattr(inst.subprocess, "run", explode)
+    lines = inst.install_claude_code(dry_run=True)
+    assert any("Would run" in line for line in lines)
+
+
+def test_claude_code_success(monkeypatch):
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        inst.subprocess,
+        "run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 0, stdout="ok", stderr=""),
+    )
+    lines = inst.install_claude_code(dry_run=False)
+    assert any("Registered" in line for line in lines)

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,106 @@
+"""Tests for the Houdini MCP menu definition.
+
+Menu items are Python embedded in XML, which nothing imports and no linter
+reads. A syntax error or a renamed function surfaces only as a menu entry that
+does nothing when clicked, in a GUI session, with the traceback buried in the
+console. These checks are cheap and catch that class of breakage without Houdini.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import ast
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# Third-party
+import pytest
+
+_MENU = Path(__file__).resolve().parents[1] / "houdini" / "MainMenuCommon.xml"
+
+# What the menu is allowed to call on the startup module. Kept explicit so
+# renaming one of these in startup.py fails here instead of in the GUI.
+_STARTUP_API = {
+    "start",
+    "stop",
+    "is_running",
+    "is_starting",
+    "get_port",
+    "ensure_running",
+}
+
+
+def _script_items() -> list[tuple[str, str]]:
+    root = ET.parse(_MENU).getroot()
+    items = []
+    for item in root.iter("scriptItem"):
+        code = item.find("scriptCode")
+        assert code is not None and code.text, f"{item.get('id')} has no scriptCode"
+        items.append((item.get("id") or "<unnamed>", code.text))
+    return items
+
+
+def test_menu_is_well_formed_xml():
+    ET.parse(_MENU)
+
+
+def test_every_script_item_compiles():
+    items = _script_items()
+    assert items, "no scriptItem found; the menu file has changed shape"
+    for name, code in items:
+        try:
+            compile(code, name, "exec")
+        except SyntaxError as exc:
+            pytest.fail(f"{name} does not compile: {exc}")
+
+
+def test_expected_items_exist():
+    """Guard against an item being dropped by an unrelated edit."""
+    ids = {name for name, _ in _script_items()}
+    assert {
+        "fxhoudinimcp_start",
+        "fxhoudinimcp_stop",
+        "fxhoudinimcp_connect",
+        "fxhoudinimcp_status",
+    } <= ids
+
+
+def test_startup_calls_exist_on_the_real_module():
+    """Every mcp.<name>() the menu calls must exist in startup.py.
+
+    The menu imports fxhoudinimcp_server.startup as ``mcp``, which lives on the
+    Houdini side of the repo and is not importable here without hou. So the
+    module is parsed rather than imported, and the calls are compared by name.
+    """
+    startup = (
+        _MENU.parent
+        / "scripts"
+        / "python"
+        / "fxhoudinimcp_server"
+        / "startup.py"
+    )
+    defined = {
+        node.name
+        for node in ast.parse(startup.read_text(encoding="utf-8")).body
+        if isinstance(node, ast.FunctionDef)
+    }
+
+    for name, code in _script_items():
+        tree = ast.parse(code)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "mcp"
+            ):
+                assert func.attr in defined, (
+                    f"{name} calls mcp.{func.attr}(), which startup.py does not "
+                    f"define. Defined: {sorted(defined)}"
+                )
+                assert func.attr in _STARTUP_API, (
+                    f"{name} calls mcp.{func.attr}(), which is not part of the "
+                    "API the menu is meant to use"
+                )


### PR DESCRIPTION
Setup was four steps across two worlds, and every one of them fails quietly.
Houdini skips a package file it cannot resolve without saying anything, and
Claude Desktop does not inherit your PATH, so a bare `python` in its config
shows up as "disconnected" with no explanation.

```shell
pip install fxhoudinimcp
fxhoudinimcp install
```

`install` writes the Houdini package file pointing at this exact install and
registers the server with Claude Code (through its own CLI, which owns the
config schema) and Claude Desktop (by merging its JSON). It uses
`sys.executable`, which removes the "disconnected" problem instead of
documenting it.

**It refuses to guess where guessing is the bug.** Several Houdini packages
directories means you choose, because a desktop-launched Houdini and a
shell-launched one can resolve different preference directories under OneDrive
redirection, and the wrong choice is invisible. One candidate means there is
nothing to choose. `--dry-run` reports every file it would touch and changes
nothing.

## A real config caught a bug in my first version

Running it against an actual Claude Desktop config found one carrying an `env`
block with `HOUDINI_HOST` and `HOUDINI_PORT`. Replacing our entry wholesale
would have **deleted the user's settings while reporting success.** Now only
`command` and `args` are ours to set, everything else in the entry survives, the
file is backed up before any write, and a config that is not parseable JSON is
left strictly alone rather than overwritten.

It also warns when an entry pins `HOUDINI_PORT`, since that silently disables the
8100-8115 scan and makes a second Houdini unreachable.

## MCP > Connect a Client...

New menu item printing the `claude mcp add` line for the port the session
actually ended up on, copied to the clipboard. The configured port and the real
one diverge as soon as a second Houdini is open. It prints a bare `python` on
purpose: from inside Houdini `sys.executable` is Houdini's own interpreter and
this side cannot find the external one, which is why it points at
`fxhoudinimcp install` for the absolute path.

## Testing

Menu items are Python inside XML that nothing imports and no linter reads, so a
typo shows up only as a menu entry that does nothing when clicked.
`tests/test_menu.py` compiles every `scriptItem` and checks each `mcp.<name>()`
call against what `startup.py` actually defines. Verified it catches a
deliberately introduced typo.

294 unit tests (24 new for the installer, 4 for the menu). Integration green on
20.5.278, 21.0.440 and 22.0.368: 125 passed, 1 skipped each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
