### PR TITLE
Make Connect a Client explain itself, and stop it handing out a footgun

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,13 @@ fxhoudinimcp install --houdini-dir "~/Documents/houdini22.0/packages"
 ```
 
 Other flags: `--client claude-code|claude-desktop|both|none` to control which
-client is touched, `none` if you wire it up yourself.
+client is touched, and `--client-only` to register a client without touching the
+Houdini side (useful on a second machine, or after moving to a different Python).
+
+Prefer `python -m fxhoudinimcp install` over the bare `fxhoudinimcp install` if
+you have more than one Python. Both work, but the module form is
+self-correcting: whichever interpreter you run it with is the one written into
+the client config, so if the command runs at all, the path it registers is right.
 
 The step-by-step version follows, for when something needs untangling.
 

--- a/houdini/MainMenuCommon.xml
+++ b/houdini/MainMenuCommon.xml
@@ -54,70 +54,135 @@ import hou
 import fxhoudinimcp_server.startup as mcp
 
 # The port the server actually ended up on, which is not always the configured
-# one: a second Houdini moves itself to the next free port. Printing the
-# configured port here would hand out a command pointing at the wrong session.
+# one: a second Houdini moves itself to the next free port. Reporting the
+# configured port here would describe the wrong session.
 port = mcp.get_port()
 
-# A bare "python" on purpose. From inside Houdini, sys.executable is Houdini's
-# own interpreter, not the external Python that has fxhoudinimcp installed, and
-# this side has no reliable way to find that one. Since clients are launched
-# without the user's shell environment, a bare name can resolve against a PATH
-# that lacks the right Python, showing up only as "disconnected" -- which is
-# exactly why the message points at `fxhoudinimcp install`, where sys.executable
-# *is* the right answer.
-command = "python -m fxhoudinimcp"
+# What to recommend, and what to put on the clipboard.
+#
+# NOT the raw `claude mcp add ... python -m fxhoudinimcp`. From inside Houdini,
+# sys.executable is Houdini's own interpreter, not the external Python that has
+# fxhoudinimcp installed, and this side cannot find that one. So a hand-written
+# command here can only say a bare "python", which is the documented cause of a
+# client reporting "disconnected": clients start their servers without the
+# user's shell environment, so the name resolves against a PATH that may not
+# contain the right Python. Worse, pasting it over a working registration would
+# replace a correct absolute path with that bare name.
+#
+# `fxhoudinimcp install --client-only` runs in the right interpreter, so
+# sys.executable *is* the answer there. --client-only skips the Houdini half,
+# which means it needs no packages directory and cannot be made ambiguous.
+recommended = "python -m fxhoudinimcp install --client-only"
 
-lines = [
-    "Register this Houdini session with an MCP client.",
+summary = [f"This Houdini session serves MCP on port {port}."]
+
+if not mcp.is_running():
+    summary += [
+        "",
+        "The server is NOT running yet. Use MCP > Start Server first, or a",
+        "client will have nothing to connect to.",
+    ]
+elif port != 8100:
+    summary += [
+        "",
+        f"Note it is on {port}, not the default 8100, because another Houdini",
+        "was already serving.",
+    ]
+
+summary += [
     "",
-    "Claude Code:",
-    f"    claude mcp add --scope user fxhoudini -- {command}",
+    "Houdini is only one half. The other half is a small Python program your",
+    "MCP client starts, which relays between the client and this session.",
+    "Registering it is a one-off, in a terminal, not in Houdini:",
+    "",
+    f"    {recommended}",
+    "",
+    "See below for what that does and how to do it by hand.",
+]
+
+details = [
+    "WHAT NEEDS TO HAPPEN",
+    "",
+    "Your MCP client (Claude Code, Claude Desktop) needs to be told how to",
+    "start the fxhoudinimcp server. That server then talks to this Houdini",
+    "session over http://127.0.0.1 on the port above. You only do this once",
+    "per machine, not once per Houdini launch.",
+    "",
+    "",
+    "THE EASY WAY",
+    "",
+    "In a terminal (PowerShell, cmd, bash), not in Houdini's Python shell:",
+    "",
+    f"    {recommended}",
+    "",
+    "What it does:",
+    "  - finds Claude Code and Claude Desktop, whichever you have",
+    "  - writes the absolute path of the Python you ran it with into their",
+    "    config, so the client can always find it",
+    "  - changes nothing about Houdini (--client-only)",
+    "",
+    "Add --dry-run to see exactly which files it would touch first.",
+    "",
+    "Why 'python -m fxhoudinimcp install' and not just 'fxhoudinimcp install':",
+    "both work, but the first is self-correcting. Whichever Python you run it",
+    "with is the one that gets registered, so if the command runs at all, the",
+    "path it writes is correct by construction.",
+    "",
+    "If it says 'No module named fxhoudinimcp', that Python does not have it.",
+    "Install it there with:  python -m pip install fxhoudinimcp",
+    "",
+    "",
+    "THE MANUAL WAY, for Claude Code",
+    "",
+    "    claude mcp add --scope user fxhoudini -- python -m fxhoudinimcp",
+    "",
+    "IMPORTANT: replace that 'python' with the FULL path to the Python that has",
+    "fxhoudinimcp installed. Here the client resolves the name itself, and it",
+    "is started without your shell environment, so a bare 'python' may not be",
+    "found or may be the wrong one. The only symptom is the client reporting",
+    "'disconnected', with nothing explaining why. Get the right path with:",
+    "",
+    "    python -c \"import sys; print(sys.executable)\"",
+    "",
+    "Already registered and want to repoint it? There is no in-place update:",
+    "",
+    "    claude mcp remove fxhoudini -s user",
+    f"    {recommended}",
 ]
 
 if port != 8100:
-    lines += [
+    details += [
         "",
-        f"This session is on port {port}, not the default 8100, because another",
-        "Houdini was already serving. The client scans 8100-8115 and picks the",
-        f"lowest, so pin this one with HOUDINI_PORT={port} if you want it",
-        "specifically.",
-    ]
-else:
-    lines += [
         "",
-        f"Serving on port {port}. The client finds this automatically.",
-    ]
-
-if not mcp.is_running():
-    lines += [
+        f"ABOUT PORT {port}",
         "",
-        "NOTE: the server is not running yet. Use MCP > Start Server first,",
-        "or the client will have nothing to connect to.",
+        f"This session moved to {port} because another Houdini already held 8100.",
+        "The client scans 8100-8115 and takes the lowest that answers, so it will",
+        "find a session on its own. To reach THIS one specifically, set",
+        f"HOUDINI_PORT={port} in the client's environment, keeping in mind that",
+        "pinning it switches the scan off.",
     ]
 
-lines += [
-    "",
-    "Easier: 'fxhoudinimcp install' does the client registration for you,",
-    "with the absolute Python path filled in.",
-]
-
-text = "\n".join(lines)
-copied = False
 try:
-    hou.ui.copyTextToClipboard(
-        f"claude mcp add --scope user fxhoudini -- {command}"
-    )
-    copied = True
+    hou.ui.copyTextToClipboard(recommended)
+    summary += ["", "(Copied to your clipboard.)"]
 except Exception:
     # Deliberately broad. There is no clipboard on a headless or remote display,
     # and the exact exception is not worth guessing: failing to copy must never
-    # stop the command being shown, which is the part that matters.
+    # stop the commands being shown, which is the part that matters. They are
+    # selectable in the details pane either way.
     pass
 
-if copied:
-    text += "\n\n(The Claude Code command is on your clipboard.)"
-
-hou.ui.displayMessage(text, title="FXHoudini-MCP: Connect a Client")
+hou.ui.displayMessage(
+    "\n".join(summary),
+    title="FXHoudini-MCP: Connect a Client",
+    details="\n".join(details),
+    details_label="Show commands",
+    # Expanded, because the whole point is to copy text out of it. The details
+    # pane is a selectable text area, so this is what makes the commands
+    # copyable rather than just readable.
+    details_expanded=True,
+)
 ]]></scriptCode>
       </scriptItem>
 

--- a/python/fxhoudinimcp/install.py
+++ b/python/fxhoudinimcp/install.py
@@ -204,6 +204,28 @@ def install_desktop(config: Path, command: list[str], dry_run: bool) -> list[str
     return lines
 
 
+def claude_code_current_command() -> str | None:
+    """The command Claude Code has registered for us, if any.
+
+    Read with `claude mcp get`, whose output is meant for humans, so this only
+    looks for the "Command:" line rather than trying to parse the whole thing.
+    Returns None when the server is not registered or the output is unfamiliar.
+    """
+    try:
+        result = subprocess.run(
+            ["claude", "mcp", "get", SERVER_NAME], capture_output=True, text=True
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    for line in (result.stdout or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Command:"):
+            return stripped.split(":", 1)[1].strip()
+    return None
+
+
 def install_claude_code(dry_run: bool) -> list[str]:
     """Register with Claude Code via its own CLI. Returns report lines."""
     argv = claude_code_add_argv()
@@ -223,13 +245,33 @@ def install_claude_code(dry_run: bool) -> list[str]:
     result = subprocess.run(argv, capture_output=True, text=True)
     if result.returncode == 0:
         return [f"  Registered '{SERVER_NAME}' with Claude Code (user scope)."]
-    detail = (result.stderr or result.stdout or "").strip().splitlines()
+
+    output = (result.stderr or "") + (result.stdout or "")
+    detail = output.strip().splitlines()
     first = detail[0] if detail else f"exit code {result.returncode}"
+
+    # `claude mcp add` has no --force, so re-running over an existing entry is
+    # an error rather than an update. That is not a problem when the entry is
+    # already correct, and reporting "failed" there sends people chasing a
+    # non-issue, so check what is actually registered before saying anything.
+    if "already exists" in output.lower():
+        current = claude_code_current_command()
+        wanted = client_command()[0]
+        if current == wanted:
+            return ["  Claude Code already points at this Python. Nothing to do."]
+        return [
+            f"  Claude Code already has '{SERVER_NAME}', pointing at:",
+            f"      {current or '<could not read it>'}",
+            "  This install is:",
+            f"      {wanted}",
+            "  It cannot be updated in place, so repoint it with:",
+            f"      claude mcp remove {SERVER_NAME} -s user",
+            "      fxhoudinimcp install --client-only",
+        ]
+
     return [
         f"  Claude Code registration failed: {first}",
-        "  Already added under this name? Remove it first:",
-        f"      claude mcp remove {SERVER_NAME}",
-        f"  Or run it yourself: {printable}",
+        f"  Run it yourself to see the whole error: {printable}",
     ]
 
 
@@ -253,14 +295,23 @@ def main(argv: list[str] | None = None) -> int:
         "whichever of the two is present)",
     )
     parser.add_argument(
+        "--client-only",
+        action="store_true",
+        help="skip the Houdini plugin and only register with the MCP client; "
+        "needs no --houdini-dir, so it works when several candidates exist",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="report what would change without changing anything",
     )
     args = parser.parse_args(argv)
 
+    if args.client_only and args.houdini_dir:
+        parser.error("--client-only and --houdini-dir contradict each other")
+
     plugin = plugin_path()
-    if not plugin.is_dir():
+    if not plugin.is_dir() and not args.client_only:
         print(
             f"The plugin directory is missing: {plugin}\n"
             "This install predates the plugin shipping inside the package "
@@ -272,10 +323,37 @@ def main(argv: list[str] | None = None) -> int:
     prefix = "Would install" if args.dry_run else "Installing"
     print(f"{prefix} FXHoudini-MCP")
     print(f"  Python : {sys.executable}")
-    print(f"  Plugin : {plugin.as_posix()}")
+    if not args.client_only:
+        print(f"  Plugin : {plugin.as_posix()}")
     print()
 
     # -- Half one: the Houdini plugin
+    if args.client_only:
+        print("Houdini plugin")
+        print("  Skipped (--client-only). The plugin already installed is left")
+        print("  exactly as it is.")
+    else:
+        result = _install_plugin_half(args, plugin)
+        if result != 0:
+            return result
+
+    _install_client_half(args)
+
+    if args.dry_run:
+        print("\nNothing was changed (--dry-run).")
+    elif args.client_only:
+        print("\nRestart your MCP client to pick up the change.")
+    else:
+        print("\nRestart Houdini, then check the MCP menu.")
+        print(
+            "MCP > Connect a Client... prints the command again, with the port "
+            "the\nserver actually ended up on."
+        )
+    return 0
+
+
+def _install_plugin_half(args, plugin: Path) -> int:
+    """Write the Houdini package file. Returns an exit code."""
     chosen, candidates, reason = resolve_houdini_dir(args.houdini_dir)
     print("Houdini plugin")
     if chosen is None:
@@ -325,7 +403,11 @@ def main(argv: list[str] | None = None) -> int:
             print(f"      {path}\n          -> {points_at}")
         print("  Delete the ones you do not want.")
 
-    # -- Half two: the MCP client
+    return 0
+
+
+def _install_client_half(args) -> None:
+    """Register the server with whichever MCP clients are in scope."""
     print("\nMCP client")
     wanted = args.client
     if wanted == "auto":
@@ -361,13 +443,3 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             for line in install_desktop(config, client_command(), args.dry_run):
                 print(line)
-
-    if args.dry_run:
-        print("\nNothing was changed (--dry-run).")
-    else:
-        print("\nRestart Houdini, then check the MCP menu.")
-        print(
-            "MCP > Connect a Client... prints the command again, with the port "
-            "the\nserver actually ended up on."
-        )
-    return 0

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -142,6 +142,51 @@ def test_dry_run_changes_nothing(plugin_dir, isolated, tmp_path, capsys):
     assert "Nothing was changed" in capsys.readouterr().out
 
 
+def test_client_only_skips_the_houdini_half(plugin_dir, isolated, tmp_path, capsys):
+    """What the MCP menu recommends, so it must not need a packages directory.
+
+    The menu cannot know which of several candidates is the right one, and a
+    command that stops to ask would be useless coming from a dialog.
+    """
+    packages = tmp_path / "packages"
+    packages.mkdir()
+
+    assert inst.main(["--client-only"]) == 0
+
+    assert not list(packages.iterdir())
+    out = capsys.readouterr().out
+    assert "Skipped (--client-only)" in out
+    assert "Restart your MCP client" in out
+
+
+def test_client_only_survives_ambiguous_candidates(
+    plugin_dir, monkeypatch, tmp_path, capsys
+):
+    """Several candidates block a normal install but must not block this one."""
+    monkeypatch.setattr(
+        inst, "candidate_package_dirs", lambda: [tmp_path / "a", tmp_path / "b"]
+    )
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
+
+    assert inst.main(["--client-only", "--client", "none"]) == 0
+    assert "Cannot choose for you" not in capsys.readouterr().out
+
+
+def test_client_only_works_without_a_plugin_directory(monkeypatch, tmp_path, capsys):
+    """Registering a client says nothing about the plugin being present."""
+    monkeypatch.setattr(inst, "plugin_path", lambda: tmp_path / "absent")
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
+
+    assert inst.main(["--client-only", "--client", "none"]) == 0
+
+
+def test_client_only_rejects_a_contradictory_houdini_dir(plugin_dir, tmp_path):
+    with pytest.raises(SystemExit):
+        inst.main(["--client-only", "--houdini-dir", str(tmp_path)])
+
+
 def test_missing_plugin_is_reported(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(inst, "plugin_path", lambda: tmp_path / "absent")
     assert inst.main([]) == 1
@@ -298,19 +343,87 @@ def test_claude_code_missing_prints_the_command(monkeypatch):
     assert any("claude mcp add" in line for line in lines)
 
 
-def test_claude_code_failure_is_explained(monkeypatch):
-    """A duplicate name is the likely failure, so name the way out of it."""
-    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+def _fails_with(message: str):
+    """A `claude mcp add` that fails with *message*."""
 
     def fake_run(argv, **kwargs):
-        return subprocess.CompletedProcess(
-            argv, 1, stdout="", stderr="server already exists"
-        )
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr=message)
 
-    monkeypatch.setattr(inst.subprocess, "run", fake_run)
+    return fake_run
+
+
+def test_already_registered_and_correct_is_not_reported_as_failure(monkeypatch):
+    """`claude mcp add` has no --force, so re-running is an error.
+
+    That is not a problem when the entry already points at this Python, and
+    calling it a failure sends people chasing a non-issue.
+    """
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        inst.subprocess, "run", _fails_with("MCP server fxhoudini already exists")
+    )
+    monkeypatch.setattr(
+        inst, "claude_code_current_command", lambda: inst.client_command()[0]
+    )
+
     lines = inst.install_claude_code(dry_run=False)
-    assert any("already exists" in line for line in lines)
-    assert any(f"claude mcp remove {inst.SERVER_NAME}" in line for line in lines)
+
+    assert any("Nothing to do" in line for line in lines)
+    assert not any("failed" in line.lower() for line in lines)
+
+
+def test_already_registered_elsewhere_shows_both_paths(monkeypatch):
+    """Repointing needs remove-then-add, and the user needs to see why."""
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        inst.subprocess, "run", _fails_with("MCP server fxhoudini already exists")
+    )
+    monkeypatch.setattr(inst, "claude_code_current_command", lambda: "/other/python")
+
+    lines = inst.install_claude_code(dry_run=False)
+    joined = "\n".join(lines)
+
+    assert "/other/python" in joined
+    assert inst.client_command()[0] in joined
+    assert f"claude mcp remove {inst.SERVER_NAME}" in joined
+
+
+def test_genuine_failure_is_reported(monkeypatch):
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(inst.subprocess, "run", _fails_with("disk on fire"))
+
+    lines = inst.install_claude_code(dry_run=False)
+
+    assert any("disk on fire" in line for line in lines)
+    assert any("failed" in line.lower() for line in lines)
+
+
+def test_current_command_parses_the_human_output(monkeypatch):
+    """`claude mcp get` prints for humans, so only the Command: line is read."""
+    output = (
+        "fxhoudini:\n"
+        "  Scope: User config\n"
+        "  Status: Connected\n"
+        "  Command: C:\\Program Files\\Python311\\python.exe\n"
+        "  Args: -m fxhoudinimcp\n"
+    )
+    monkeypatch.setattr(
+        inst.subprocess,
+        "run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 0, stdout=output),
+    )
+    assert (
+        inst.claude_code_current_command() == "C:\\Program Files\\Python311\\python.exe"
+    )
+
+
+def test_current_command_none_when_not_registered(monkeypatch):
+    monkeypatch.setattr(
+        inst.subprocess,
+        "run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 1, stdout=""),
+    )
+    assert inst.claude_code_current_command() is None
 
 
 def test_claude_code_dry_run_does_not_shell_out(monkeypatch):

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -65,6 +65,142 @@ def test_expected_items_exist():
     } <= ids
 
 
+def _run_item(item_id: str, port: int = 8100, running: bool = True) -> dict:
+    """Execute a menu item against fake hou/startup modules, capturing the dialog.
+
+    The menu only ever runs in a GUI Houdini, where hou.ui exists; hython has no
+    hou.ui at all, so the alternative is shipping this code untested. Faking the
+    two modules it touches exercises the real branching.
+    """
+    import sys
+    import types
+
+    captured: dict = {}
+
+    class FakeUI:
+        def copyTextToClipboard(self, text):
+            captured["clipboard"] = text
+
+        def displayMessage(self, text, **kwargs):
+            captured["text"] = text
+            captured.update(kwargs)
+
+    hou = types.ModuleType("hou")
+    hou.ui = FakeUI()
+    hou.severityType = types.SimpleNamespace(Error="error")
+
+    startup = types.ModuleType("fxhoudinimcp_server.startup")
+    startup.get_port = lambda: port
+    startup.is_running = lambda: running
+    startup.is_starting = lambda: False
+    startup.start = lambda *a, **k: None
+    startup.stop = lambda: None
+    package = types.ModuleType("fxhoudinimcp_server")
+    package.startup = startup
+
+    code = dict(_script_items())[item_id]
+    saved = {name: sys.modules.get(name) for name in ("hou", "fxhoudinimcp_server")}
+    sys.modules["hou"] = hou
+    sys.modules["fxhoudinimcp_server"] = package
+    sys.modules["fxhoudinimcp_server.startup"] = startup
+    try:
+        exec(compile(code, item_id, "exec"), {})
+    finally:
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        sys.modules.pop("fxhoudinimcp_server.startup", None)
+    return captured
+
+
+def test_connect_dialog_recommends_the_self_correcting_command():
+    """It must not hand out a bare `python` in a `claude mcp add` line.
+
+    From inside Houdini there is no way to find the external Python that has
+    fxhoudinimcp installed, so a ready-to-paste `claude mcp add` would carry a
+    bare `python` -- the documented cause of a client reporting "disconnected",
+    and worse, pasting it over a working registration would replace a correct
+    absolute path with that bare name.
+    """
+    dialog = _run_item("fxhoudinimcp_connect")
+
+    assert dialog["clipboard"] == "python -m fxhoudinimcp install --client-only"
+    assert "claude mcp add" not in dialog["clipboard"]
+    assert "claude mcp add" in dialog["details"], (
+        "the manual route should still be documented, just not handed over "
+        "ready to paste"
+    )
+
+
+def test_connect_dialog_details_are_expanded_and_explain_the_command():
+    """The details pane is what makes the commands selectable, so it must be open."""
+    dialog = _run_item("fxhoudinimcp_connect")
+
+    assert dialog["details_expanded"] is True
+    assert dialog["details_label"]
+    # Naming the command is not enough: it has to say where to run it and what
+    # it will do, which is the part that was confusing.
+    assert "terminal" in dialog["details"].lower()
+    assert "What it does" in dialog["details"]
+    assert "No module named fxhoudinimcp" in dialog["details"]
+
+
+def test_connect_dialog_reports_the_real_port():
+    default = _run_item("fxhoudinimcp_connect", port=8100)
+    moved = _run_item("fxhoudinimcp_connect", port=8103)
+
+    assert "8100" in default["text"]
+    assert "8103" in moved["text"]
+    # A moved port needs explaining, since the client scans and takes the lowest.
+    assert "8103" in moved["details"]
+    assert "HOUDINI_PORT=8103" in moved["details"]
+    assert "HOUDINI_PORT" not in default["details"]
+
+
+def test_connect_dialog_warns_when_the_server_is_stopped():
+    stopped = _run_item("fxhoudinimcp_connect", running=False)
+    assert "NOT running" in stopped["text"]
+
+
+def test_connect_dialog_survives_a_broken_clipboard():
+    """Failing to copy must never stop the commands being shown."""
+    import sys
+    import types
+
+    captured: dict = {}
+
+    class FakeUI:
+        def copyTextToClipboard(self, text):
+            raise RuntimeError("no clipboard on this display")
+
+        def displayMessage(self, text, **kwargs):
+            captured["text"] = text
+            captured.update(kwargs)
+
+    hou = types.ModuleType("hou")
+    hou.ui = FakeUI()
+    startup = types.ModuleType("fxhoudinimcp_server.startup")
+    startup.get_port = lambda: 8100
+    startup.is_running = lambda: True
+    package = types.ModuleType("fxhoudinimcp_server")
+    package.startup = startup
+
+    code = dict(_script_items())["fxhoudinimcp_connect"]
+    sys.modules["hou"] = hou
+    sys.modules["fxhoudinimcp_server"] = package
+    sys.modules["fxhoudinimcp_server.startup"] = startup
+    try:
+        exec(compile(code, "connect", "exec"), {})
+    finally:
+        for name in ("hou", "fxhoudinimcp_server", "fxhoudinimcp_server.startup"):
+            sys.modules.pop(name, None)
+
+    assert captured["details"]
+    assert "clipboard" not in captured["text"].lower()
+
+
 def test_startup_calls_exist_on_the_real_module():
     """Every mcp.<name>() the menu calls must exist in startup.py.
 


### PR DESCRIPTION
Clicking the menu item copied this:

```
claude mcp add --scope user fxhoudini -- python -m fxhoudinimcp
```

Two problems, both mine. That bare `python` is the documented cause of a client
reporting "disconnected", since the client resolves the name itself and starts
without the user's shell environment. Worse, **pasting it over a working
registration replaces a correct absolute path with that bare name**, undoing what
`fxhoudinimcp install` had just got right. Handing someone a command that
degrades their setup is not a convenience.

## The clipboard now carries something that cannot be wrong

```
python -m fxhoudinimcp install --client-only
```

Self-correcting by construction: whichever interpreter runs it is the one written
into the client config, so if it runs at all, the registered path is right.

`--client-only` is new. It skips the Houdini half, so it needs no packages
directory and cannot be blocked by the ambiguity that stops a full install, which
matters because a dialog that stopped to ask which of three directories to use
would be useless.

## It explains the shape of the thing now

Naming a command was not enough. The dialog says that Houdini is one half and the
client starts the other, that this is a one-off in a terminal rather than in
Houdini's Python shell, what the command will change, why the module form is
preferred, and what to do when the answer is "No module named fxhoudinimcp". The
manual `claude mcp add` route is still documented with the absolute-path
requirement spelled out, it is just no longer handed over ready to paste.

Using `details`/`details_label`/`details_expanded` puts all of it in a selectable
text area, so commands can be copied rather than retyped from a screenshot.

## Re-running is no longer reported as a failure

`claude mcp add` has no `--force`, so a second run over an existing entry errors,
and calling that "registration failed" sends people chasing a non-issue. It now
reads what is actually registered with `claude mcp get` and reports either
"already points at this Python, nothing to do" or both paths plus the
remove-then-re-run fix. Genuine failures still report as failures.

## Testing

Menu items only ever run in a GUI Houdini, where `hou.ui` exists, so hython
cannot reach them and the alternative was shipping this untested.
`tests/test_menu.py` executes the item against fake `hou` and `startup` modules
and asserts on the resulting dialog: the clipboard never contains
`claude mcp add`, the details are expanded and genuinely explain the command, a
moved port is reported and explained, and a broken clipboard cannot stop the
message appearing.

307 unit tests. Integration green on 20.5.278 and 22.0.368: 125 passed, 1 skipped
each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
