### PR TITLE
Stop the entry point swallowing unknown commands, and add `uninstall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,25 @@ client config, so if the command runs at all, the path it registers is correct.
 Add `--dry-run` first if you want to see every file it would touch and change
 nothing.
 
-It stops rather than guessing when it cannot know the answer. If several Houdini
-packages directories exist it lists them and asks, because choosing wrongly
-produces an install that fails **silently**:
+It asks rather than guessing when it cannot know the answer. Several Houdini
+packages directories usually means several Houdini versions, so it lists them
+and lets you pick one, or all of them:
+
+```
+Houdini plugin
+  Several Houdini packages directories exist.
+  Which does the Houdini you want to use read?
+      1) C:\Users\you\Documents\houdini21.0\packages
+      2) C:\Users\you\Documents\houdini22.0\packages
+      a) all of them
+      q) cancel
+  Choose [1-2/a/q]:
+```
+
+Choosing wrongly produces an install that fails **silently**, which is why it
+will not choose for you. When there is no terminal to ask, running from the MCP
+menu or a setup script, it prints the same list and exits non-zero. Name the
+directory up front to skip the question entirely:
 
 ```shell
 python -m fxhoudinimcp install --houdini-dir "~/Documents/houdini22.0/packages"
@@ -195,6 +211,33 @@ clone** instead of the installed package (see [by hand](#installing-by-hand)),
 `pip install --upgrade` will not move that half. Those two halves are then
 independent, and the server warns at startup when it finds a plugin older than
 itself.
+
+### Uninstalling
+
+`pip uninstall` moves neither half. The Houdini package file and the client
+registration both outlive it, and both fail quietly once the package is gone: a
+package file pointing at a plugin directory that no longer exists is skipped by
+Houdini without a word, and a stale client entry shows up only as
+"disconnected". So take the two halves out first, then the package:
+
+```shell
+python -m fxhoudinimcp uninstall
+pip uninstall fxhoudinimcp
+```
+
+`uninstall` lists everything it found and asks before removing any of it. Unlike
+`install` it does not need to know which Houdini you meant: every
+`fxhoudinimcp.json` it finds is a leftover, and the one you forget is exactly
+what silently overrides your next install. Narrow it with `--houdini-dir` when
+you only want one Houdini cleaned.
+
+| Flag | What it removes |
+| --- | --- |
+| `--dry-run` | Nothing. Lists what it would remove |
+| `--houdini-dir DIR` | Only this packages directory, instead of every one found |
+| `--client-only` | Only the client registration, leaving the package files |
+| `--client auto\|claude-code\|claude-desktop\|both\|none` | Which client to unregister from |
+| `--yes` | Skip the confirmation. Required when stdin is not a terminal |
 
 ### Configuring the plugin
 
@@ -341,11 +384,32 @@ A working package prints both a `Loading:` and a `Processing:` line for
 - **A second `fxhoudinimcp.json`.** Houdini processes every packages directory
   and the last one wins, so a leftover file can override a fresh install. Both
   commands warn when they find another one. `fxhoudinimcp houdini-package` lists
-  every one it can see, and what each points at.
+  every one it can see, and what each points at, and `fxhoudinimcp uninstall`
+  removes the lot.
+- **No package file for the Houdini you launched.** Each Houdini version reads
+  its own preference directory, so installing into `houdini21.0/packages` does
+  nothing for a Houdini 22 you start afterwards. Answer `a` at the prompt, or
+  run `install` once per version.
 
 On Windows, note that OneDrive's Documents redirection means a desktop-launched
 Houdini and a shell-launched one can resolve different preference directories.
 The package log is what settles which one your Houdini actually reads.
+
+### Checking what you are actually running
+
+An editable install reports the version it was created at, not whatever the
+working tree has become since, so an old checkout can be running while the
+metadata claims otherwise:
+
+```shell
+python -m fxhoudinimcp --version
+```
+
+Worth checking first whenever a documented subcommand behaves as though it does
+not exist. Before 2.5.0, an unrecognised argument was ignored and the MCP server
+started instead, so `python -m fxhoudinimcp install` on an older install printed
+a warning about not reaching Houdini and then sat there, looking like a hung
+installer. It now exits with `unknown command` and the list of real ones.
 <!-- --8<-- [end:installation] -->
 
 <!-- USAGE -->

--- a/python/fxhoudinimcp/__init__.py
+++ b/python/fxhoudinimcp/__init__.py
@@ -1,3 +1,14 @@
 """FXHoudini-MCP: Comprehensive MCP server for SideFX Houdini."""
 
-__version__ = "0.1.0"
+from __future__ import annotations
+
+try:
+    # Written at build time by hatch-vcs, so it is the only place that knows
+    # the real version. This used to be a hardcoded "0.1.0", which meant
+    # fxhoudinimcp.__version__ disagreed with the package metadata, with
+    # mcp._mcp_server.version, and with the truth, from 1.0.0 onwards.
+    from fxhoudinimcp._version import __version__
+except ImportError:  # pragma: no cover - a source tree that was never built
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/python/fxhoudinimcp/__main__.py
+++ b/python/fxhoudinimcp/__main__.py
@@ -1,4 +1,24 @@
-"""Entry point for the FXHoudini MCP server."""
+"""Entry point for the FXHoudini MCP server.
+
+Two jobs that pull in opposite directions. With no arguments this must start the
+MCP server on stdio and print nothing else, because that is the contract every
+MCP client launches it under. With arguments it is a normal command line tool
+and has to behave like one.
+
+Getting that balance wrong is what made issue #28 so hard to read. Subcommands
+were matched by name and everything else fell through to ``mcp.run()``, so
+running a subcommand your installed version did not have started a server:
+
+    $ python -m fxhoudinimcp install
+    WARNING:fxhoudinimcp.server:Cannot reach Houdini at startup: ...
+    WARNING:fxhoudinimcp.server:Tools will attempt to connect on first use.
+
+Nothing installed, nothing said so, and the two warnings point at Houdini, which
+was never involved. So unrecognised arguments are now an error, and ``--version``
+exists because "which version am I actually running" was the question that
+unlocked it: an editable install reports the commit it was created at, not
+whatever the working tree has since become.
+"""
 
 from __future__ import annotations
 
@@ -6,32 +26,112 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import Callable
+
+
+def _run_install(argv: list[str]) -> int:
+    # Imported inside the subcommand so that no-argument startup, the hot path
+    # for every MCP client, does not pay for the installer.
+    from fxhoudinimcp.install import main as install_main
+
+    return install_main(argv)
+
+
+def _run_uninstall(argv: list[str]) -> int:
+    from fxhoudinimcp.uninstall import main as uninstall_main
+
+    return uninstall_main(argv)
+
+
+def _run_houdini_package(argv: list[str]) -> int:
+    from fxhoudinimcp.houdini_package import main as houdini_package_main
+
+    return houdini_package_main(argv)
+
+
+# The commands this entry point accepts, each with the one-line summary shown in
+# the usage text. Kept as one table so a command cannot exist without being
+# listed, which is how the missing-subcommand failure stayed invisible.
+SUBCOMMANDS: dict[str, tuple[Callable[[list[str]], int], str]] = {
+    "install": (
+        _run_install,
+        "install the Houdini plugin and register an MCP client",
+    ),
+    "uninstall": (
+        _run_uninstall,
+        "remove the Houdini plugin file and the client registration",
+    ),
+    "houdini-package": (
+        _run_houdini_package,
+        "print or write the Houdini package file",
+    ),
+}
+
+_HELP_FLAGS = ("-h", "--help")
+_VERSION_FLAGS = ("-V", "--version")
+
+
+def usage() -> str:
+    """The usage text, built from the command table so it cannot drift."""
+    width = max(len(name) for name in SUBCOMMANDS)
+    commands = "\n".join(
+        f"    {name.ljust(width)}   {summary}"
+        for name, (_, summary) in SUBCOMMANDS.items()
+    )
+    return (
+        "usage: python -m fxhoudinimcp [<command>] [<args>]\n"
+        "\n"
+        "With no arguments, runs the MCP server on stdio. That is how an MCP\n"
+        "client starts it, and it is the default.\n"
+        "\n"
+        "Commands:\n"
+        f"{commands}\n"
+        "\n"
+        "Run any command with --help for its own options.\n"
+        "\n"
+        "Options:\n"
+        "    -h, --help      show this message\n"
+        "    -V, --version   show the installed version\n"
+    )
 
 
 def main() -> None:
-    # Subcommands are handled before the MCP plumbing loads: the server is
-    # normally launched by an MCP client with no arguments, so argparse-ing the
-    # whole entry point would risk changing that contract.
-    if len(sys.argv) > 1 and sys.argv[1] == "houdini-package":
-        from fxhoudinimcp.houdini_package import main as houdini_package_main
+    argv = sys.argv[1:]
 
-        raise SystemExit(houdini_package_main(sys.argv[2:]))
+    if argv:
+        command, rest = argv[0], argv[1:]
 
-    if len(sys.argv) > 1 and sys.argv[1] == "install":
-        from fxhoudinimcp.install import main as install_main
+        if command in SUBCOMMANDS:
+            runner, _ = SUBCOMMANDS[command]
+            raise SystemExit(runner(rest))
 
-        raise SystemExit(install_main(sys.argv[2:]))
+        if command in _HELP_FLAGS:
+            print(usage(), end="")
+            raise SystemExit(0)
+
+        if command in _VERSION_FLAGS:
+            from fxhoudinimcp import __version__
+
+            print(__version__)
+            raise SystemExit(0)
+
+        # Never fall through to the server. An unrecognised argument is a
+        # mistake, and starting a stdio server in response to a mistake looks
+        # exactly like a hung install.
+        print(f"unknown command: {command}\n", file=sys.stderr)
+        print(usage(), end="", file=sys.stderr)
+        raise SystemExit(2)
 
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     logging.basicConfig(level=getattr(logging, log_level, logging.INFO))
 
     # Import server (triggers tool, resource, and prompt registration)
-    from fxhoudinimcp.server import mcp  # noqa: F811
+    from fxhoudinimcp import prompts as _prompts  # noqa: F401
+    from fxhoudinimcp import resources as _resources  # noqa: F401
 
     # Force import all tool modules to register them
     from fxhoudinimcp import tools as _tools  # noqa: F401
-    from fxhoudinimcp import resources as _resources  # noqa: F401
-    from fxhoudinimcp import prompts as _prompts  # noqa: F401
+    from fxhoudinimcp.server import mcp  # noqa: F811
 
     transport = os.getenv("MCP_TRANSPORT", "stdio")
     mcp.run(transport=transport)

--- a/python/fxhoudinimcp/houdini_package.py
+++ b/python/fxhoudinimcp/houdini_package.py
@@ -25,9 +25,10 @@ import argparse
 import json
 import platform
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
-_PACKAGE_NAME = "fxhoudinimcp.json"
+PACKAGE_NAME = "fxhoudinimcp.json"
 
 
 def plugin_path() -> Path:
@@ -87,7 +88,24 @@ def candidate_package_dirs() -> list[Path]:
     return found
 
 
-def existing_packages(exclude: Path | None = None) -> list[tuple[Path, str]]:
+def _comparable(path: Path) -> Path:
+    """A path that compares equal to one built from ``Path.home()``.
+
+    ``--houdini-dir`` is used exactly as typed, so a relative path, or one
+    containing ``..``, does not match the absolute candidates this module
+    builds, and the file the installer has just written comes back as somebody
+    else's leftover with advice to delete it. Case is already handled: Windows
+    paths compare case-insensitively.
+    """
+    try:
+        return path.resolve()
+    except OSError:  # pragma: no cover - unreadable mount, nothing better to do
+        return path
+
+
+def existing_packages(
+    exclude: Path | Iterable[Path] | None = None,
+) -> list[tuple[Path, str]]:
     """Find already-installed package files and the plugin path each points at.
 
     Two of these is a real hazard rather than a tidiness issue. Houdini processes
@@ -98,13 +116,24 @@ def existing_packages(exclude: Path | None = None) -> list[tuple[Path, str]]:
         WARNING: var FXHOUDINIMCP overwritten with ...
 
     Reported so the operator can delete the stale one.
+
+    *exclude* takes one path or many, because a single install can now write
+    into every Houdini version on the machine, and warning about the files it
+    just wrote would contradict itself.
     """
+    if exclude is None:
+        excluded: set[Path] = set()
+    elif isinstance(exclude, Path):
+        excluded = {_comparable(exclude)}
+    else:
+        excluded = {_comparable(path) for path in exclude}
+
     found: list[tuple[Path, str]] = []
     for directory in candidate_package_dirs():
-        candidate = directory / _PACKAGE_NAME
+        candidate = directory / PACKAGE_NAME
         if not candidate.is_file():
             continue
-        if exclude is not None and candidate == exclude:
+        if _comparable(candidate) in excluded:
             continue
         target = "<unreadable>"
         try:
@@ -134,7 +163,7 @@ def write_package(destination: Path, path: Path | None = None) -> Path:
     """
     if not destination.is_dir():
         raise NotADirectoryError(destination)
-    target = destination / _PACKAGE_NAME
+    target = destination / PACKAGE_NAME
     target.write_text(package_json(path), encoding="utf-8", newline="\n")
     return target
 
@@ -190,7 +219,7 @@ def main(argv: list[str] | None = None) -> int:
         others = existing_packages(exclude=target)
         if others:
             print(
-                f"\nWARNING: {len(others)} other {_PACKAGE_NAME} also exists. "
+                f"\nWARNING: {len(others)} other {PACKAGE_NAME} also exists. "
                 "Houdini processes every packages directory and the last one "
                 "wins, so a leftover file can silently override this install:"
             )
@@ -202,7 +231,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print(f"Plugin directory:\n    {plugin.as_posix()}\n")
-    print(f"Put this in a Houdini packages directory as {_PACKAGE_NAME}:\n")
+    print(f"Put this in a Houdini packages directory as {PACKAGE_NAME}:\n")
     print(contents)
 
     candidates = candidate_package_dirs()
@@ -222,6 +251,6 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "\nTo verify Houdini picked it up, start Houdini with "
         "HOUDINI_PACKAGE_VERBOSE=1\nand look for a 'Processing:' line for "
-        f"{_PACKAGE_NAME}."
+        f"{PACKAGE_NAME}."
     )
     return 0

--- a/python/fxhoudinimcp/install.py
+++ b/python/fxhoudinimcp/install.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 # Internal
 from fxhoudinimcp.houdini_package import (
+    PACKAGE_NAME,
     candidate_package_dirs,
     existing_packages,
     plugin_path,
@@ -106,6 +107,63 @@ def resolve_houdini_dir(explicit: str | None) -> tuple[Path | None, list[Path], 
     if len(candidates) == 1:
         return candidates[0], candidates, "the only candidate on this machine"
     return None, candidates, f"{len(candidates)} candidates, so the choice is yours"
+
+
+def stdin_is_interactive() -> bool:
+    """Whether there is a person on the other end who can answer a question.
+
+    Not cosmetic. This command is also run from Houdini's MCP menu and from
+    setup scripts, where stdin is not a terminal and ``input()`` either raises
+    immediately or blocks forever with a prompt nobody can see. Those callers
+    keep the printed list and the non-zero exit.
+    """
+    try:
+        return sys.stdin is not None and sys.stdin.isatty()
+    except ValueError:  # stdin closed underneath us
+        return False
+
+
+def prompt_for_package_dirs(candidates: list[Path]) -> list[Path]:
+    """Ask which packages directories to write into. Empty means cancelled.
+
+    Refusing to guess was right, but it is only half an answer: the command knew
+    the candidates, printed them, and then made the operator retype one. Asking
+    costs nothing and removes the transcription error.
+
+    "All of them" is offered because several candidates usually means several
+    Houdini versions rather than one ambiguous location. Someone running 21.0
+    and 22.0 wants the menu in both, and two runs is an invitation to do one.
+    """
+    print("  Several Houdini packages directories exist.")
+    print("  Which does the Houdini you want to use read?")
+    for index, candidate in enumerate(candidates, start=1):
+        print(f"      {index}) {candidate}")
+    print("      a) all of them")
+    print("      q) cancel")
+    print(
+        "\n  On Windows with OneDrive redirecting Documents, a desktop-launched\n"
+        "  Houdini and a shell-launched one can disagree. Start Houdini with\n"
+        "  HOUDINI_PACKAGE_VERBOSE=1 to see which it reads."
+    )
+
+    choices = f"1-{len(candidates)}" if len(candidates) > 1 else "1"
+    while True:
+        try:
+            answer = input(f"  Choose [{choices}/a/q]: ").strip().lower()
+        except EOFError:
+            # A piped stdin that runs dry. Looping would hang.
+            print()
+            return []
+        if answer == "q":
+            return []
+        if answer == "a":
+            return list(candidates)
+        if answer.isdigit() and 1 <= int(answer) <= len(candidates):
+            return [candidates[int(answer) - 1]]
+        if answer:
+            print(f"  Not one of the choices: {answer!r}")
+        else:
+            print("  Not one of the choices: nothing was entered")
 
 
 def _merge_desktop_config(existing: dict, command: list[str]) -> dict:
@@ -363,56 +421,90 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _report_missing_directory(destination: Path) -> None:
+    print(f"  Not a directory: {destination}", file=sys.stderr)
+    print("  Create it first, or pass a different --houdini-dir.", file=sys.stderr)
+
+
+def _choose_destinations(args) -> tuple[list[Path], str] | None:
+    """Work out where the package file goes. None means stop, non-zero exit."""
+    chosen, candidates, reason = resolve_houdini_dir(args.houdini_dir)
+
+    if chosen is not None:
+        return [chosen], reason
+
+    if not candidates:
+        print(f"  {reason.capitalize()}.")
+        print(
+            "  Create one inside your Houdini preferences directory, for "
+            "example\n      Documents/houdini22.0/packages\n"
+            "  then re-run this command."
+        )
+        return None
+
+    if not stdin_is_interactive():
+        print(f"  Cannot choose for you: {reason}.")
+        for candidate in candidates:
+            print(f"      {candidate}")
+        print("\n  Re-run with the one your Houdini actually reads:")
+        print(f'      fxhoudinimcp install --houdini-dir "{candidates[0]}"')
+        print(
+            "\n  On Windows with OneDrive redirecting Documents, a "
+            "desktop-launched\n  Houdini and a shell-launched one can "
+            "disagree. Start Houdini with\n  HOUDINI_PACKAGE_VERBOSE=1 to "
+            "see which it reads."
+        )
+        return None
+
+    destinations = prompt_for_package_dirs(candidates)
+    if not destinations:
+        print("  Cancelled. Nothing was written.")
+        return None
+    return destinations, "chosen at the prompt"
+
+
 def _install_plugin_half(args, plugin: Path) -> int:
     """Write the Houdini package file. Returns an exit code."""
-    chosen, candidates, reason = resolve_houdini_dir(args.houdini_dir)
     print("Houdini plugin")
-    if chosen is None:
-        if candidates:
-            print(f"  Cannot choose for you: {reason}.")
-            for candidate in candidates:
-                print(f"      {candidate}")
-            print("\n  Re-run with the one your Houdini actually reads:")
-            print(f'      fxhoudinimcp install --houdini-dir "{candidates[0]}"')
-            print(
-                "\n  On Windows with OneDrive redirecting Documents, a "
-                "desktop-launched\n  Houdini and a shell-launched one can "
-                "disagree. Start Houdini with\n  HOUDINI_PACKAGE_VERBOSE=1 to "
-                "see which it reads."
-            )
-        else:
-            print(f"  {reason.capitalize()}.")
-            print(
-                "  Create one inside your Houdini preferences directory, for "
-                "example\n      Documents/houdini22.0/packages\n"
-                "  then re-run this command."
-            )
-        return 1
 
-    if args.dry_run:
-        print(f"  Would write fxhoudinimcp.json into {chosen} ({reason})")
-    else:
+    resolved = _choose_destinations(args)
+    if resolved is None:
+        return 1
+    destinations, reason = resolved
+
+    # Every destination is checked before any is written, so a typo in the
+    # second one cannot leave the first half-installed. It also keeps --dry-run
+    # honest: it used to report "Would write" for a directory that does not
+    # exist, and then the real run refused.
+    for destination in destinations:
+        if not destination.is_dir():
+            _report_missing_directory(destination)
+            return 1
+
+    for destination in destinations:
+        if args.dry_run:
+            print(f"  Would write {PACKAGE_NAME} into {destination} ({reason})")
+            continue
         try:
-            written = write_package(chosen, plugin)
-        except NotADirectoryError:
-            print(f"  Not a directory: {chosen}", file=sys.stderr)
-            print(
-                "  Create it first, or pass a different --houdini-dir.",
-                file=sys.stderr,
-            )
+            written = write_package(destination, plugin)
+        except NotADirectoryError:  # pragma: no cover - lost a race with rmdir
+            _report_missing_directory(destination)
             return 1
         print(f"  Wrote {written} ({reason})")
 
-    others = existing_packages(exclude=chosen / "fxhoudinimcp.json")
+    others = existing_packages(
+        exclude=[destination / PACKAGE_NAME for destination in destinations]
+    )
     if others:
         print(
-            f"\n  WARNING: {len(others)} other fxhoudinimcp.json exists. Houdini "
+            f"\n  WARNING: {len(others)} other {PACKAGE_NAME} exists. Houdini "
             "processes every\n  packages directory and the last one wins, so a "
             "leftover file can silently\n  override this install:"
         )
         for path, points_at in others:
             print(f"      {path}\n          -> {points_at}")
-        print("  Delete the ones you do not want.")
+        print("  Delete the ones you do not want, or run:")
+        print("      python -m fxhoudinimcp uninstall")
 
     return 0
 

--- a/python/fxhoudinimcp/uninstall.py
+++ b/python/fxhoudinimcp/uninstall.py
@@ -1,0 +1,316 @@
+"""Take both halves back out again.
+
+``install`` writes into two places that outlive the Python package: a Houdini
+packages directory, and an MCP client's config. ``pip uninstall`` moves neither,
+so removing this used to mean knowing where both live and editing them by hand.
+
+The leftovers are not harmless, and they fail in the quiet way this project
+keeps running into. A package file pointing at a plugin directory that no longer
+exists is skipped by Houdini without a word. A client entry pointing at a
+removed interpreter surfaces only as "disconnected". And a forgotten
+``fxhoudinimcp.json`` in a second packages directory silently overrides the next
+install, because Houdini processes every packages directory and the last one
+wins.
+
+    fxhoudinimcp uninstall                    # remove both halves, after asking
+    fxhoudinimcp uninstall --dry-run          # list what it would remove
+    fxhoudinimcp uninstall --yes              # do not ask
+    fxhoudinimcp uninstall --houdini-dir DIR  # only this packages directory
+    fxhoudinimcp uninstall --client none      # leave client configs alone
+
+Unlike ``install``, this does not have to pick between candidate directories.
+Installing has to know which Houdini you mean; removing does not, because every
+``fxhoudinimcp.json`` found is a leftover and leaving one behind is the hazard
+above. So the default is all of them, listed in full before anything is deleted.
+
+The Python package is deliberately left alone. That is ``pip uninstall
+fxhoudinimcp``, and running it on someone's behalf from inside the package being
+removed is a good way to produce a half-deleted install.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Internal
+from fxhoudinimcp.houdini_package import PACKAGE_NAME, existing_packages
+from fxhoudinimcp.install import (
+    SERVER_NAME,
+    claude_code_available,
+    desktop_config_path,
+    stdin_is_interactive,
+)
+
+
+def claude_code_remove_argv(scope: str = "user") -> list[str]:
+    """The `claude mcp remove` invocation, for running or for printing."""
+    return ["claude", "mcp", "remove", SERVER_NAME, "-s", scope]
+
+
+def find_package_files(houdini_dir: str | None) -> list[Path]:
+    """Every ``fxhoudinimcp.json`` this uninstall would remove.
+
+    With ``--houdini-dir`` only that one directory is considered, so a machine
+    with several Houdini versions can have one cleaned without touching the
+    rest. Without it, every candidate directory is searched, which is the point:
+    the file you forget is the one that breaks the next install.
+    """
+    if houdini_dir:
+        candidate = Path(houdini_dir).expanduser() / PACKAGE_NAME
+        return [candidate] if candidate.is_file() else []
+    return [path for path, _ in existing_packages()]
+
+
+def confirm(question: str) -> bool:
+    """Ask before deleting. Anything but an explicit yes is no."""
+    try:
+        return input(f"  {question} [y/N]: ").strip().lower() in ("y", "yes")
+    except EOFError:
+        print()
+        return False
+
+
+def remove_package_files(paths: list[Path], dry_run: bool) -> list[str]:
+    """Delete the Houdini package files. Returns report lines."""
+    lines: list[str] = []
+    for path in paths:
+        if dry_run:
+            lines.append(f"  Would remove {path}")
+            continue
+        try:
+            path.unlink()
+        except OSError as exc:
+            lines.append(f"  Could not remove {path}: {exc}")
+            continue
+        lines.append(f"  Removed {path}")
+    return lines
+
+
+def remove_desktop_entry(config: Path, dry_run: bool) -> list[str]:
+    """Drop our entry from Claude Desktop's config, keeping everything else.
+
+    The same care ``install`` takes, for the same reason: this file is likely to
+    hold servers that took someone effort to set up, and an uninstaller that
+    eats them is worse than one that never ran.
+    """
+    if not config.is_file():
+        return [f"  Claude Desktop has no config at {config}. Nothing to remove."]
+
+    try:
+        existing = json.loads(config.read_text(encoding="utf-8-sig")) or {}
+    except Exception as exc:
+        return [
+            f"  SKIPPED Claude Desktop: {config} is not readable JSON ({exc}).",
+            "          Fix or remove it by hand. It was left untouched.",
+        ]
+    if not isinstance(existing, dict):
+        return [
+            f"  SKIPPED Claude Desktop: {config} is not a JSON object.",
+            "          It was left untouched.",
+        ]
+
+    servers = existing.get("mcpServers") or {}
+    if SERVER_NAME not in servers:
+        return [f"  Claude Desktop has no '{SERVER_NAME}' entry. Nothing to remove."]
+
+    if dry_run:
+        return [f"  Would remove '{SERVER_NAME}' from {config}"]
+
+    backup = config.with_suffix(config.suffix + ".bak")
+    shutil.copy2(config, backup)
+    remaining = dict(servers)
+    del remaining[SERVER_NAME]
+    updated = dict(existing)
+    updated["mcpServers"] = remaining
+    config.write_text(
+        json.dumps(updated, indent=2) + "\n", encoding="utf-8", newline="\n"
+    )
+    return [
+        f"  Backed up {backup.name}",
+        f"  Removed '{SERVER_NAME}' from {config}",
+        "  Fully quit Claude Desktop (tray > Quit) and relaunch.",
+    ]
+
+
+def remove_claude_code(dry_run: bool) -> list[str]:
+    """Unregister from Claude Code via its own CLI. Returns report lines."""
+    argv = claude_code_remove_argv()
+    printable = " ".join(argv)
+
+    if not claude_code_available():
+        return [
+            "  Claude Code CLI not on PATH, so nothing was changed. Run this",
+            "  yourself if you use Claude Code:",
+            f"      {printable}",
+        ]
+    if dry_run:
+        return [f"  Would run: {printable}"]
+
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode == 0:
+        return [f"  Removed '{SERVER_NAME}' from Claude Code (user scope)."]
+
+    output = (result.stderr or "") + (result.stdout or "")
+    # Removing something that is not there is the desired end state, not a
+    # failure, and reporting it as one sends people looking for a problem.
+    if "no mcp server" in output.lower() or "not found" in output.lower():
+        return [f"  Claude Code has no '{SERVER_NAME}' entry. Nothing to remove."]
+
+    detail = output.strip().splitlines()
+    first = detail[0] if detail else f"exit code {result.returncode}"
+    return [
+        f"  Claude Code removal failed: {first}",
+        f"  Run it yourself to see the whole error: {printable}",
+    ]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The argument parser, exposed so the README's flag table can be checked."""
+    parser = argparse.ArgumentParser(
+        prog="fxhoudinimcp uninstall",
+        description="Remove the Houdini package file and the MCP client "
+        "registration written by `fxhoudinimcp install`.",
+    )
+    parser.add_argument(
+        "--houdini-dir",
+        metavar="DIR",
+        help="only clean this packages directory (default: every one found)",
+    )
+    parser.add_argument(
+        "--client",
+        choices=("auto", "claude-code", "claude-desktop", "both", "none"),
+        default="auto",
+        help="which MCP client to unregister from (default: auto, meaning "
+        "whichever of the two is present)",
+    )
+    parser.add_argument(
+        "--client-only",
+        action="store_true",
+        help="unregister the client and leave the Houdini package files alone",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be removed without removing anything",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="do not ask for confirmation; required when stdin is not a terminal",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.client_only and args.houdini_dir:
+        parser.error("--client-only and --houdini-dir contradict each other")
+
+    prefix = "Would remove" if args.dry_run else "Removing"
+    print(f"{prefix} FXHoudini-MCP")
+    print(f"  Python : {sys.executable}")
+    print()
+
+    package_files = [] if args.client_only else find_package_files(args.houdini_dir)
+
+    print("Houdini plugin")
+    if args.client_only:
+        print("  Skipped (--client-only). Package files were left in place.")
+    elif not package_files:
+        where = args.houdini_dir or "any Houdini packages directory found"
+        print(f"  No {PACKAGE_NAME} in {where}. Nothing to remove.")
+    else:
+        for path in package_files:
+            print(f"      {path}")
+
+    targets = _client_targets(args)
+
+    if not package_files and not targets:
+        print("\nNothing to do.")
+        _report_python_package()
+        return 0
+
+    if not args.dry_run and not args.yes and not _confirmed(package_files, targets):
+        return 1
+
+    if package_files:
+        print()
+        for line in remove_package_files(package_files, args.dry_run):
+            print(line)
+
+    print("\nMCP client")
+    if not targets:
+        print("  Skipped. No client config was touched.")
+    for target in targets:
+        if target == "claude-code":
+            lines = remove_claude_code(args.dry_run)
+        else:
+            config = desktop_config_path()
+            if config is None:
+                print("  Could not locate Claude Desktop's config on this platform.")
+                continue
+            lines = remove_desktop_entry(config, args.dry_run)
+        for line in lines:
+            print(line)
+
+    if args.dry_run:
+        print("\nNothing was changed (--dry-run).")
+    else:
+        print("\nRestart Houdini and your MCP client to pick up the change.")
+    _report_python_package()
+    return 0
+
+
+def _client_targets(args) -> list[str]:
+    """Which client configs are in scope, mirroring `install`'s --client."""
+    if args.client == "none":
+        return []
+    if args.client == "both":
+        return ["claude-code", "claude-desktop"]
+    if args.client != "auto":
+        return [args.client]
+
+    targets = []
+    if claude_code_available():
+        targets.append("claude-code")
+    config = desktop_config_path()
+    if config is not None and config.is_file():
+        targets.append("claude-desktop")
+    return targets
+
+
+def _confirmed(package_files: list[Path], targets: list[str]) -> bool:
+    """Ask before deleting, and refuse to assume when nobody can be asked.
+
+    A script that pipes this command nothing gets a refusal rather than a
+    deletion. --yes is how a script says it meant it.
+    """
+    if not stdin_is_interactive():
+        print(
+            "\nRefusing to remove anything without confirmation. Re-run with "
+            "--yes,\nor with --dry-run to see the full list first.",
+            file=sys.stderr,
+        )
+        return False
+
+    count = len(package_files) + len(targets)
+    print()
+    if not confirm(f"Remove {count} item(s) listed above?"):
+        print("  Cancelled. Nothing was removed.")
+        return False
+    return True
+
+
+def _report_python_package() -> None:
+    print(
+        "\nThe Python package is still installed. Remove it with:\n"
+        "    pip uninstall fxhoudinimcp"
+    )

--- a/tests/test_houdini_package.py
+++ b/tests/test_houdini_package.py
@@ -127,6 +127,36 @@ class TestExistingPackages:
 
         assert hp.existing_packages(exclude=mine) == []
 
+    def test_excludes_several_files_at_once(self, monkeypatch, tmp_path):
+        """Installing into two Houdini versions writes two files, not one."""
+        mine = self._write(tmp_path / "a", "/plugins/mine")
+        also_mine = self._write(tmp_path / "b", "/plugins/mine")
+        theirs = self._write(tmp_path / "c", "/plugins/theirs")
+        monkeypatch.setattr(
+            hp,
+            "candidate_package_dirs",
+            lambda: [tmp_path / "a", tmp_path / "b", tmp_path / "c"],
+        )
+
+        assert hp.existing_packages(exclude=[mine, also_mine]) == [
+            (theirs, "/plugins/theirs")
+        ]
+
+    def test_excludes_a_path_spelled_differently(self, monkeypatch, tmp_path):
+        """--houdini-dir is taken as typed, so it need not match character for
+        character the absolute paths this module builds from Path.home().
+
+        Without normalising, a relative or dot-containing --houdini-dir made the
+        installer warn that the file it had just written was a leftover from
+        some other install, and tell you to delete it.
+        """
+        mine = self._write(tmp_path / "a", "/plugins/mine")
+        monkeypatch.setattr(hp, "candidate_package_dirs", lambda: [tmp_path / "a"])
+        roundabout = tmp_path / "a" / ".." / "a" / "fxhoudinimcp.json"
+
+        assert roundabout != mine  # the comparison that used to be made
+        assert hp.existing_packages(exclude=roundabout) == []
+
     def test_a_corrupt_file_is_reported_not_fatal(self, monkeypatch, tmp_path):
         (tmp_path / "a").mkdir()
         (tmp_path / "a" / "fxhoudinimcp.json").write_text("{broken", encoding="utf-8")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 # Internal
+from fxhoudinimcp import houdini_package as hp
 from fxhoudinimcp import install as inst
 
 
@@ -447,6 +448,220 @@ def test_claude_code_success(monkeypatch):
     )
     lines = inst.install_claude_code(dry_run=False)
     assert any("Registered" in line for line in lines)
+
+
+###### Choosing between several candidates, at the prompt
+
+
+def _answers(monkeypatch, *replies: str) -> None:
+    """Feed *replies* to input() in order, then behave like a closed stdin."""
+    pending = list(replies)
+
+    def fake_input(prompt: str = "") -> str:
+        if not pending:
+            raise EOFError
+        return pending.pop(0)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+@pytest.fixture
+def interactive(monkeypatch):
+    """A terminal on the other end, so the installer is allowed to ask."""
+    monkeypatch.setattr(inst, "stdin_is_interactive", lambda: True)
+
+
+@pytest.fixture
+def two_candidates(monkeypatch, tmp_path):
+    """Two real packages directories, the shape of a 21.0 + 22.0 machine."""
+    first, second = tmp_path / "houdini21.0", tmp_path / "houdini22.0"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [first, second])
+    monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
+    return first, second
+
+
+def test_prompt_lists_every_candidate(monkeypatch, tmp_path, capsys):
+    first, second = tmp_path / "a", tmp_path / "b"
+    _answers(monkeypatch, "1")
+
+    assert inst.prompt_for_package_dirs([first, second]) == [first]
+
+    out = capsys.readouterr().out
+    assert str(first) in out
+    assert str(second) in out
+
+
+def test_prompt_returns_the_numbered_choice(monkeypatch, tmp_path):
+    first, second = tmp_path / "a", tmp_path / "b"
+    _answers(monkeypatch, "2")
+    assert inst.prompt_for_package_dirs([first, second]) == [second]
+
+
+def test_prompt_can_take_all_of_them(monkeypatch, tmp_path):
+    """Several candidates is usually several Houdini versions, not ambiguity.
+
+    Someone running 21.0 and 22.0 side by side wants the menu in both, and
+    making them run the command twice invites doing it once and forgetting.
+    """
+    first, second = tmp_path / "a", tmp_path / "b"
+    _answers(monkeypatch, "a")
+    assert inst.prompt_for_package_dirs([first, second]) == [first, second]
+
+
+def test_prompt_can_be_cancelled(monkeypatch, tmp_path):
+    _answers(monkeypatch, "q")
+    assert inst.prompt_for_package_dirs([tmp_path / "a", tmp_path / "b"]) == []
+
+
+def test_prompt_treats_end_of_input_as_cancel(monkeypatch, tmp_path):
+    """A piped stdin that runs dry must not loop forever."""
+    _answers(monkeypatch)
+    assert inst.prompt_for_package_dirs([tmp_path / "a", tmp_path / "b"]) == []
+
+
+def test_prompt_re_asks_rather_than_guessing(monkeypatch, tmp_path, capsys):
+    """Out of range, not a number, and empty are all re-asked, never rounded."""
+    first, second = tmp_path / "a", tmp_path / "b"
+    _answers(monkeypatch, "3", "yes", "", "1")
+
+    assert inst.prompt_for_package_dirs([first, second]) == [first]
+
+    out = capsys.readouterr().out
+    assert out.count("Not one of the choices") == 3
+    assert "nothing was entered" in out  # a bare Return is rejected, not defaulted
+
+
+def test_ambiguous_dir_prompts_and_writes_only_the_choice(
+    plugin_dir, interactive, two_candidates, monkeypatch
+):
+    first, second = two_candidates
+    _answers(monkeypatch, "2")
+
+    assert inst.main(["--client", "none"]) == 0
+
+    assert not list(first.iterdir())
+    assert (second / "fxhoudinimcp.json").is_file()
+
+
+def test_choosing_all_writes_into_every_candidate(
+    plugin_dir, interactive, two_candidates, monkeypatch
+):
+    first, second = two_candidates
+    _answers(monkeypatch, "a")
+
+    assert inst.main(["--client", "none"]) == 0
+
+    assert (first / "fxhoudinimcp.json").is_file()
+    assert (second / "fxhoudinimcp.json").is_file()
+
+
+def test_cancelling_writes_nothing_and_exits_nonzero(
+    plugin_dir, interactive, two_candidates, monkeypatch, capsys
+):
+    first, second = two_candidates
+    _answers(monkeypatch, "q")
+
+    assert inst.main(["--client", "none"]) == 1
+
+    assert not list(first.iterdir())
+    assert not list(second.iterdir())
+    assert "Cancelled" in capsys.readouterr().out
+
+
+def test_a_non_interactive_run_never_stops_to_ask(
+    plugin_dir, two_candidates, monkeypatch, capsys
+):
+    """The MCP menu and any script run this with no terminal attached.
+
+    input() there either raises immediately or blocks forever, and a Houdini
+    menu item that hangs on a prompt nobody can see is worse than one that
+    prints instructions. So the old list-and-refuse behaviour is kept, and
+    reaching input() at all is treated as the failure it would be.
+    """
+    monkeypatch.setattr(inst, "stdin_is_interactive", lambda: False)
+
+    def explode(prompt: str = "") -> str:
+        raise AssertionError("a non-interactive install must not call input()")
+
+    monkeypatch.setattr("builtins.input", explode)
+    first, second = two_candidates
+
+    assert inst.main(["--client", "none"]) == 1
+
+    assert not list(first.iterdir())
+    assert not list(second.iterdir())
+    assert "Cannot choose for you" in capsys.readouterr().out
+
+
+def test_an_explicit_dir_never_prompts(plugin_dir, interactive, tmp_path, monkeypatch):
+    """--houdini-dir already answered the question."""
+    packages = tmp_path / "packages"
+    packages.mkdir()
+    monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
+
+    def explode(prompt: str = "") -> str:
+        raise AssertionError("--houdini-dir must not be second-guessed")
+
+    monkeypatch.setattr("builtins.input", explode)
+
+    assert inst.main(["--houdini-dir", str(packages), "--client", "none"]) == 0
+    assert (packages / "fxhoudinimcp.json").is_file()
+
+
+###### A dry run has to be honest about what would fail
+
+
+def test_dry_run_rejects_a_directory_that_does_not_exist(
+    plugin_dir, isolated, tmp_path, capsys
+):
+    """A dry run that reports success for a write that would fail is worthless.
+
+    It was reporting "Would write ... into C:\\nowhere" and exiting 0, while the
+    real run refused. The whole point of --dry-run is to be believed.
+    """
+    missing = tmp_path / "not-created"
+
+    assert inst.main(["--houdini-dir", str(missing), "--dry-run"]) == 1
+    assert "Not a directory" in capsys.readouterr().err
+
+
+def test_nothing_is_written_when_one_destination_is_missing(
+    plugin_dir, interactive, monkeypatch, tmp_path
+):
+    """Every destination is checked before the first one is written."""
+    first, second = tmp_path / "a", tmp_path / "b"
+    first.mkdir()  # second is never created
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [first, second])
+    monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
+    _answers(monkeypatch, "a")
+
+    assert inst.main(["--client", "none"]) == 1
+    assert not list(first.iterdir())
+
+
+def test_the_files_just_written_are_not_reported_as_leftovers(
+    plugin_dir, interactive, two_candidates, monkeypatch, capsys
+):
+    """Writing both and then warning about both would be self-contradictory.
+
+    Runs the real detector rather than the stub, because the whole question is
+    whether it recognises the files this run has just created.
+    """
+    first, second = two_candidates
+    monkeypatch.setattr(inst, "existing_packages", hp.existing_packages)
+    monkeypatch.setattr(hp, "candidate_package_dirs", lambda: [first, second])
+    _answers(monkeypatch, "a")
+
+    assert inst.main(["--client", "none"]) == 0
+    assert "WARNING" not in capsys.readouterr().out
 
 
 ###### The README's flag table

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,179 @@
+"""Tests for the module entry point.
+
+This file exists because of one bug, and the bug is worth writing down. The
+entry point used to match its subcommands by name and let everything else fall
+through to ``mcp.run(transport="stdio")``. So on any version predating a given
+subcommand, typing it started an MCP server instead:
+
+    $ python -m fxhoudinimcp install
+    WARNING:fxhoudinimcp.server:Cannot reach Houdini at startup: ...
+    WARNING:fxhoudinimcp.server:Tools will attempt to connect on first use.
+
+Nothing was installed, nothing said so, and the process sat there holding stdin.
+It reads as a hung installer, and the two warnings send you looking at Houdini,
+which is the one part that was never involved. A typo produced the same thing.
+
+So the contract is now explicit in both directions, and both directions are
+tested: no arguments starts the server, because every MCP client depends on
+that, and anything unrecognised exits non-zero without importing the server.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import sys
+
+# Third-party
+import pytest
+
+# Internal
+from fxhoudinimcp import __main__ as entry
+
+
+def _run(monkeypatch, *argv: str) -> int:
+    """Run the entry point with *argv* and return its exit code."""
+    monkeypatch.setattr(sys, "argv", ["fxhoudinimcp", *argv])
+    with pytest.raises(SystemExit) as exit_info:
+        entry.main()
+    code = exit_info.value.code
+    return 0 if code is None else int(code)
+
+
+###### The contract an MCP client relies on
+
+
+def test_no_arguments_runs_the_server_on_stdio(monkeypatch):
+    """The default, and the only behaviour a client ever asks for."""
+    # Internal
+    from fxhoudinimcp import server
+
+    started: dict[str, str] = {}
+    monkeypatch.setattr(
+        server.mcp, "run", lambda transport: started.update(transport=transport)
+    )
+    monkeypatch.setattr(sys, "argv", ["fxhoudinimcp"])
+
+    entry.main()
+
+    assert started == {"transport": "stdio"}
+
+
+def test_transport_is_still_overridable(monkeypatch):
+    # Internal
+    from fxhoudinimcp import server
+
+    started: dict[str, str] = {}
+    monkeypatch.setattr(
+        server.mcp, "run", lambda transport: started.update(transport=transport)
+    )
+    monkeypatch.setattr(sys, "argv", ["fxhoudinimcp"])
+    monkeypatch.setenv("MCP_TRANSPORT", "sse")
+
+    entry.main()
+
+    assert started == {"transport": "sse"}
+
+
+###### Unrecognised arguments
+
+
+def test_unknown_command_exits_nonzero(monkeypatch, capsys):
+    assert _run(monkeypatch, "definitely-not-a-command") == 2
+    assert "unknown command" in capsys.readouterr().err
+
+
+def test_a_mistyped_subcommand_does_not_start_a_server(monkeypatch, capsys):
+    """The exact shape of the original report, one keystroke away."""
+    assert _run(monkeypatch, "instal") == 2
+    assert "instal" in capsys.readouterr().err
+
+
+def test_unknown_command_shows_what_is_accepted(monkeypatch, capsys):
+    """Being told "no" is only half of it, since the whole failure was silence."""
+    _run(monkeypatch, "nope")
+
+    err = capsys.readouterr().err
+    for command in entry.SUBCOMMANDS:
+        assert command in err
+
+
+def test_an_unknown_option_is_rejected_too(monkeypatch, capsys):
+    """Options and subcommands fall through identically, so both are checked."""
+    assert _run(monkeypatch, "--houdini-dir", "/somewhere") == 2
+    assert "unknown command" in capsys.readouterr().err
+
+
+###### Help and version
+
+
+def test_help_exits_zero_and_lists_every_subcommand(monkeypatch, capsys):
+    assert _run(monkeypatch, "--help") == 0
+
+    out = capsys.readouterr().out
+    for command in entry.SUBCOMMANDS:
+        assert command in out
+
+
+def test_help_is_available_as_dash_h(monkeypatch, capsys):
+    assert _run(monkeypatch, "-h") == 0
+    assert "usage:" in capsys.readouterr().out
+
+
+def test_usage_describes_every_subcommand(monkeypatch, capsys):
+    """The usage text is built from the table, so it cannot drift out of date."""
+    _run(monkeypatch, "--help")
+
+    out = capsys.readouterr().out
+    for command, (_, summary) in entry.SUBCOMMANDS.items():
+        assert command in out
+        assert summary in out
+
+
+def test_version_reports_the_installed_version(monkeypatch, capsys):
+    """The question nobody could answer during the original report.
+
+    An editable install carries the version it was created at, so the answer
+    here is what distinguishes "the command is broken" from "this checkout
+    predates the command".
+    """
+    # Internal
+    from fxhoudinimcp import __version__
+
+    assert _run(monkeypatch, "--version") == 0
+    assert capsys.readouterr().out.strip() == __version__
+
+
+def test_version_is_not_the_placeholder():
+    """__init__ used to hardcode 0.1.0, which was wrong for every release."""
+    # Internal
+    from fxhoudinimcp import __version__
+
+    assert __version__ != "0.1.0"
+
+
+###### Dispatch
+
+
+@pytest.mark.parametrize("command", sorted(entry.SUBCOMMANDS))
+def test_subcommand_is_dispatched_with_its_own_arguments(
+    monkeypatch, command: str
+) -> None:
+    """Everything after the subcommand belongs to the subcommand, untouched."""
+    seen: dict[str, list[str]] = {}
+    _, summary = entry.SUBCOMMANDS[command]
+    monkeypatch.setitem(
+        entry.SUBCOMMANDS,
+        command,
+        (lambda argv: seen.update(argv=argv) or 0, summary),
+    )
+
+    assert _run(monkeypatch, command, "--dry-run", "--client", "none") == 0
+    assert seen["argv"] == ["--dry-run", "--client", "none"]
+
+
+def test_subcommand_exit_code_is_propagated(monkeypatch):
+    """`install` returns 1 when it refuses to guess, and that must reach the shell."""
+    _, summary = entry.SUBCOMMANDS["install"]
+    monkeypatch.setitem(entry.SUBCOMMANDS, "install", (lambda argv: 1, summary))
+
+    assert _run(monkeypatch, "install") == 1

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -1,0 +1,396 @@
+"""Tests for the uninstaller.
+
+An uninstaller is held to a stricter standard than an installer, because its
+mistakes are not recoverable by re-running it. So the tests are mostly about
+restraint: never delete without saying what and asking first, never assume
+consent from a script that cannot be asked, and never touch the parts of a
+Claude Desktop config that belong to somebody else's servers.
+
+The one place it is deliberately less cautious than `install` is the choice of
+directory. Installing has to know which Houdini you mean. Removing does not:
+every fxhoudinimcp.json found is a leftover, and the one left behind is exactly
+what silently overrides the next install.
+"""
+
+from __future__ import annotations
+
+# Built-in
+import json
+import re
+import subprocess
+from pathlib import Path
+
+# Third-party
+import pytest
+
+# Internal
+from fxhoudinimcp import uninstall as uninst
+
+
+def _package_file(directory: Path, target: str = "/plugins/somewhere") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / "fxhoudinimcp.json"
+    path.write_text(
+        json.dumps({"env": [{"FXHOUDINIMCP": target}], "path": "$FXHOUDINIMCP"}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _answers(monkeypatch, *replies: str) -> None:
+    pending = list(replies)
+
+    def fake_input(prompt: str = "") -> str:
+        if not pending:
+            raise EOFError
+        return pending.pop(0)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+
+@pytest.fixture
+def no_clients(monkeypatch):
+    """No MCP client on the machine, so the Houdini half can be tested alone."""
+    monkeypatch.setattr(uninst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(uninst, "desktop_config_path", lambda: None)
+
+
+@pytest.fixture
+def interactive(monkeypatch):
+    monkeypatch.setattr(uninst, "stdin_is_interactive", lambda: True)
+
+
+###### Finding what to remove
+
+
+def test_finds_every_package_file(monkeypatch, tmp_path):
+    """The forgotten one is the whole problem, so the default is all of them."""
+    first = _package_file(tmp_path / "h21")
+    second = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(first, ""), (second, "")])
+
+    assert uninst.find_package_files(None) == [first, second]
+
+
+def test_an_explicit_dir_narrows_it_to_one(tmp_path):
+    mine = _package_file(tmp_path / "h22")
+    _package_file(tmp_path / "h21")
+
+    assert uninst.find_package_files(str(tmp_path / "h22")) == [mine]
+
+
+def test_an_explicit_dir_with_nothing_in_it_finds_nothing(tmp_path):
+    (tmp_path / "empty").mkdir()
+    assert uninst.find_package_files(str(tmp_path / "empty")) == []
+
+
+###### Consent
+
+
+def test_nothing_is_removed_without_confirmation(
+    monkeypatch, no_clients, interactive, tmp_path, capsys
+):
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+    _answers(monkeypatch, "n")
+
+    assert uninst.main([]) == 1
+
+    assert mine.is_file()
+    assert "Cancelled" in capsys.readouterr().out
+
+
+def test_a_bare_return_is_not_consent(
+    monkeypatch, no_clients, interactive, tmp_path
+):
+    """The prompt reads [y/N], so the default has to actually be no."""
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+    _answers(monkeypatch, "")
+
+    assert uninst.main([]) == 1
+    assert mine.is_file()
+
+
+def test_a_script_that_cannot_be_asked_is_refused(
+    monkeypatch, no_clients, tmp_path, capsys
+):
+    """No terminal means no consent. --yes is how a script says it meant it."""
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+    monkeypatch.setattr(uninst, "stdin_is_interactive", lambda: False)
+
+    def explode(prompt: str = "") -> str:
+        raise AssertionError("must not prompt when stdin is not a terminal")
+
+    monkeypatch.setattr("builtins.input", explode)
+
+    assert uninst.main([]) == 1
+
+    assert mine.is_file()
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_yes_removes_without_asking(monkeypatch, no_clients, tmp_path):
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+    monkeypatch.setattr(uninst, "stdin_is_interactive", lambda: False)
+
+    assert uninst.main(["--yes"]) == 0
+    assert not mine.exists()
+
+
+def test_confirming_removes_every_file(
+    monkeypatch, no_clients, interactive, tmp_path
+):
+    first = _package_file(tmp_path / "h21")
+    second = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(
+        uninst, "existing_packages", lambda: [(first, ""), (second, "")]
+    )
+    _answers(monkeypatch, "y")
+
+    assert uninst.main([]) == 0
+
+    assert not first.exists()
+    assert not second.exists()
+
+
+def test_what_will_be_removed_is_listed_before_the_question(
+    monkeypatch, no_clients, interactive, tmp_path, capsys
+):
+    """Consent to an unseen list is not consent."""
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+    _answers(monkeypatch, "y")
+
+    uninst.main([])
+
+    assert str(mine) in capsys.readouterr().out
+
+
+###### Dry run
+
+
+def test_dry_run_removes_nothing_and_never_asks(
+    monkeypatch, no_clients, tmp_path, capsys
+):
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+
+    def explode(prompt: str = "") -> str:
+        raise AssertionError("--dry-run has nothing to consent to")
+
+    monkeypatch.setattr("builtins.input", explode)
+
+    assert uninst.main(["--dry-run"]) == 0
+
+    assert mine.is_file()
+    out = capsys.readouterr().out
+    assert "Would remove" in out
+    assert "Nothing was changed" in out
+
+
+def test_nothing_to_do_is_not_an_error(monkeypatch, no_clients, capsys):
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [])
+    assert uninst.main([]) == 0
+    assert "Nothing to do" in capsys.readouterr().out
+
+
+###### Scope
+
+
+def test_client_only_leaves_the_package_files(
+    monkeypatch, no_clients, interactive, tmp_path, capsys
+):
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+
+    assert uninst.main(["--client-only", "--yes"]) == 0
+
+    assert mine.is_file()
+    assert "Skipped (--client-only)" in capsys.readouterr().out
+
+
+def test_client_only_rejects_a_contradictory_houdini_dir(tmp_path):
+    with pytest.raises(SystemExit):
+        uninst.main(["--client-only", "--houdini-dir", str(tmp_path)])
+
+
+def test_client_none_touches_no_config(monkeypatch, tmp_path, capsys):
+    mine = _package_file(tmp_path / "h22")
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [(mine, "")])
+    monkeypatch.setattr(uninst, "stdin_is_interactive", lambda: False)
+
+    def explode() -> bool:
+        raise AssertionError("--client none must not look for clients")
+
+    monkeypatch.setattr(uninst, "claude_code_available", explode)
+
+    assert uninst.main(["--yes", "--client", "none"]) == 0
+
+    assert not mine.exists()
+    assert "No client config was touched" in capsys.readouterr().out
+
+
+def test_the_python_package_is_left_alone_and_said_so(
+    monkeypatch, no_clients, capsys
+):
+    """Removing the package from inside itself is how you get a half-install."""
+    monkeypatch.setattr(uninst, "existing_packages", lambda: [])
+
+    uninst.main([])
+
+    assert "pip uninstall fxhoudinimcp" in capsys.readouterr().out
+
+
+###### Claude Desktop config
+
+
+def test_desktop_removal_preserves_other_servers(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "other": {"command": "node", "args": ["x.js"]},
+                    uninst.SERVER_NAME: {"command": "/py"},
+                },
+                "someUnrelatedKey": {"keep": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    uninst.remove_desktop_entry(config, dry_run=False)
+
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert data["mcpServers"] == {"other": {"command": "node", "args": ["x.js"]}}
+    assert data["someUnrelatedKey"] == {"keep": True}
+
+
+def test_desktop_removal_backs_up_first(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    original = {"mcpServers": {uninst.SERVER_NAME: {"command": "/py"}}}
+    config.write_text(json.dumps(original), encoding="utf-8")
+
+    uninst.remove_desktop_entry(config, dry_run=False)
+
+    backup = config.with_suffix(config.suffix + ".bak")
+    assert json.loads(backup.read_text(encoding="utf-8")) == original
+
+
+def test_desktop_removal_leaves_an_unparseable_config_alone(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    config.write_text("{ this is not json", encoding="utf-8")
+
+    lines = uninst.remove_desktop_entry(config, dry_run=False)
+
+    assert config.read_text(encoding="utf-8") == "{ this is not json"
+    assert any("SKIPPED" in line for line in lines)
+
+
+def test_desktop_removal_is_quiet_when_there_is_nothing_to_remove(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    config.write_text(json.dumps({"mcpServers": {"other": {}}}), encoding="utf-8")
+
+    lines = uninst.remove_desktop_entry(config, dry_run=False)
+
+    assert any("Nothing to remove" in line for line in lines)
+    assert not config.with_suffix(config.suffix + ".bak").exists()
+
+
+def test_desktop_dry_run_writes_nothing(tmp_path):
+    config = tmp_path / "claude_desktop_config.json"
+    config.write_text(
+        json.dumps({"mcpServers": {uninst.SERVER_NAME: {"command": "/py"}}}),
+        encoding="utf-8",
+    )
+    before = config.read_text(encoding="utf-8")
+
+    lines = uninst.remove_desktop_entry(config, dry_run=True)
+
+    assert config.read_text(encoding="utf-8") == before
+    assert any("Would remove" in line for line in lines)
+
+
+###### Claude Code
+
+
+def test_claude_code_missing_prints_the_command(monkeypatch):
+    monkeypatch.setattr(uninst, "claude_code_available", lambda: False)
+    lines = uninst.remove_claude_code(dry_run=False)
+    assert any("claude mcp remove" in line for line in lines)
+
+
+def test_removing_something_absent_is_not_a_failure(monkeypatch):
+    """The desired end state was already true, which is not an error."""
+    monkeypatch.setattr(uninst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        uninst.subprocess,
+        "run",
+        lambda argv, **kw: subprocess.CompletedProcess(
+            argv, 1, stdout="", stderr="No MCP server found with name: fxhoudini"
+        ),
+    )
+
+    lines = uninst.remove_claude_code(dry_run=False)
+
+    assert any("Nothing to remove" in line for line in lines)
+    assert not any("failed" in line.lower() for line in lines)
+
+
+def test_a_genuine_failure_is_reported(monkeypatch):
+    monkeypatch.setattr(uninst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        uninst.subprocess,
+        "run",
+        lambda argv, **kw: subprocess.CompletedProcess(
+            argv, 1, stdout="", stderr="disk on fire"
+        ),
+    )
+
+    lines = uninst.remove_claude_code(dry_run=False)
+
+    assert any("disk on fire" in line for line in lines)
+    assert any("failed" in line.lower() for line in lines)
+
+
+def test_removal_argv_targets_the_user_scope(monkeypatch):
+    """install registers at user scope, so uninstall has to look there."""
+    assert uninst.claude_code_remove_argv() == [
+        "claude",
+        "mcp",
+        "remove",
+        uninst.SERVER_NAME,
+        "-s",
+        "user",
+    ]
+
+
+###### The README's flag table
+
+
+_README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def test_readme_flag_table_matches_the_cli():
+    """Same drift check the installer's table gets, for the same reason."""
+    text = _README.read_text(encoding="utf-8")
+    table = re.search(r"\n\| Flag \| What it removes \|\n(.+?)\n\n", text, re.S)
+    assert table, "the uninstall flag table has moved or been removed from README.md"
+    documented = set(re.findall(r"`(--[a-z-]+)", table.group(1)))
+
+    parser = uninst.build_parser()
+    real = {
+        option
+        for action in parser._actions
+        for option in action.option_strings
+        if option.startswith("--") and option != "--help"
+    }
+
+    assert documented == real, (
+        f"README and CLI disagree.\n"
+        f"  documented but gone: {sorted(documented - real)}\n"
+        f"  real but undocumented: {sorted(real - documented)}"
+    )


### PR DESCRIPTION
`python -m fxhoudinimcp install` on a version predating that command started an
MCP server instead of erroring. Unrecognised argv fell through to
`mcp.run(transport="stdio")`, so the entire output was:

```
WARNING:fxhoudinimcp.server:Cannot reach Houdini at startup: ...
WARNING:fxhoudinimcp.server:Tools will attempt to connect on first use.
```

Nothing installed, nothing said so, and both warnings point at Houdini, which
was never involved. It reads as a hung installer, and a typo produced the same
thing.

Subcommands now live in one table that the usage text is generated from, so a
command cannot exist without being listed, and anything unrecognised exits 2
with that list. No-argument startup is unchanged and now has a test holding it
there, since every MCP client depends on it.

### Also here

- **`--version`.** "Which version am I actually running" was the question that
  unlocked the above: an editable install reports the commit it was created at,
  not what the working tree has since become.
- **`fxhoudinimcp.__version__` was hardcoded `"0.1.0"`,** disagreeing with the
  package metadata and with `mcp._mcp_server.version` since 1.0.0.
- **`install` now asks** which packages directory to use, rather than printing
  the candidates and making you retype one. It offers all of them, because
  several candidates usually means several Houdini versions rather than one
  ambiguous path, and installing into `houdini21.0` does nothing for a Houdini
  22 you start afterwards. Only when stdin is a terminal: the MCP menu and
  setup scripts run this without one, and a menu item blocking on an invisible
  prompt would be worse than the bug being fixed.
- **`--dry-run` was reporting "Would write"** for a directory that does not
  exist, while the real run refused. Destinations are validated in both modes,
  and all of them before any is written.
- **`existing_packages(exclude=...)` compared paths as typed,** so a relative
  `--houdini-dir` made the file just written come back as somebody else's
  leftover, with advice to delete it.
- **`uninstall`,** because pip moves neither half. A package file pointing at a
  plugin that no longer exists is skipped by Houdini in silence, and a stale
  client entry reads only as "disconnected". It lists what it found and asks,
  refuses without `--yes` when there is no terminal to ask, preserves the rest
  of a Claude Desktop config, and leaves the pip package alone.

### Verification

- 366 tests pass, 55 of them new (`tests/test_main.py`, `tests/test_uninstall.py`).
- Wheel built and installed into a clean venv: `plugin_path()` resolves to the
  packaged `fxhoudinimcp/houdini` rather than the source-tree fallback, the
  35 plugin files are present including `python3.13libs`, no `__pycache__`
  leaked, and `--version` / unknown-command / `uninstall --dry-run` all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
