### PR TITLE
Make `install` finish instead of handing back homework

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,29 +168,32 @@ client config, so if the command runs at all, the path it registers is correct.
 Add `--dry-run` first if you want to see every file it would touch and change
 nothing.
 
-It asks rather than guessing when it cannot know the answer. Several Houdini
-packages directories usually means several Houdini versions, so it lists them
-and lets you pick one, or all of them:
+It asks nothing and it finishes. If you have several Houdini versions, it writes
+into every packages directory it finds:
 
 ```
 Houdini plugin
-  Several Houdini packages directories exist.
-  Which does the Houdini you want to use read?
-      1) C:\Users\you\Documents\houdini21.0\packages
-      2) C:\Users\you\Documents\houdini22.0\packages
-      a) all of them
-      q) cancel
-  Choose [1-2/a/q]:
+  Wrote C:\Users\you\Documents\houdini21.0\packages\fxhoudinimcp.json
+  Wrote C:\Users\you\Documents\houdini22.0\packages\fxhoudinimcp.json
 ```
 
-Choosing wrongly produces an install that fails **silently**, which is why it
-will not choose for you. When there is no terminal to ask, running from the MCP
-menu or a setup script, it prints the same list and exits non-zero. Name the
-directory up front to skip the question entirely:
+That is safe rather than lazy. The files are identical and point at the same
+plugin, so whichever directory your Houdini reads, it finds a correct one. It
+also settles the Windows case where OneDrive's Documents redirection makes a
+desktop-launched Houdini and a shell-launched one disagree: both paths get a
+file, so both work. The cost is an **MCP** menu in a Houdini version you may not
+use, which `uninstall` clears in one go.
+
+Because it never stops to ask, the same command works unchanged from a terminal,
+from Houdini's MCP menu, or from a setup script. To target one directory only:
 
 ```shell
 python -m fxhoudinimcp install --houdini-dir "~/Documents/houdini22.0/packages"
 ```
+
+If your MCP client already has an `fxhoudini` entry pointing at a different
+interpreter, it is repointed at this one and the old value is printed. That is
+the common case after switching Python versions or recreating a virtualenv.
 
 | Flag | What it does |
 | --- | --- |
@@ -387,9 +390,11 @@ A working package prints both a `Loading:` and a `Processing:` line for
   every one it can see, and what each points at, and `fxhoudinimcp uninstall`
   removes the lot.
 - **No package file for the Houdini you launched.** Each Houdini version reads
-  its own preference directory, so installing into `houdini21.0/packages` does
-  nothing for a Houdini 22 you start afterwards. Answer `a` at the prompt, or
-  run `install` once per version.
+  its own preference directory, so a file in `houdini21.0/packages` does nothing
+  for a Houdini 22 you start afterwards. `install` writes to every candidate for
+  exactly this reason; you only see this if you narrowed it with
+  `--houdini-dir`, or if that Houdini's `packages` directory did not exist when
+  you ran it. Create it and re-run.
 
 On Windows, note that OneDrive's Documents redirection means a desktop-launched
 Houdini and a shell-launched one can resolve different preference directories.

--- a/python/fxhoudinimcp/compat.py
+++ b/python/fxhoudinimcp/compat.py
@@ -83,6 +83,7 @@ def compatibility_warning(available: list[str] | None) -> str | None:
         f"need those commands will fail. The packaged plugin travels with this "
         f"install, so the likely cause is a Houdini package file pointing "
         f"somewhere else, for example an older clone. Run "
-        f"'fxhoudinimcp houdini-package' to see the path this install expects "
+        f"'python -m fxhoudinimcp houdini-package' to see the path this install "
+        f"expects "
         f"and to be warned about competing package files."
     )

--- a/python/fxhoudinimcp/houdini_package.py
+++ b/python/fxhoudinimcp/houdini_package.py
@@ -30,6 +30,13 @@ from pathlib import Path
 
 PACKAGE_NAME = "fxhoudinimcp.json"
 
+# How to spell this tool in anything somebody might copy. The bare console
+# script resolves against PATH, which is the wrong interpreter as soon as there
+# is more than one Python. The README says to use the module form for exactly
+# that reason, so printing the bare form in our own messages contradicted our
+# own advice, in the place people are most likely to follow it: an error.
+CLI = "python -m fxhoudinimcp"
+
 
 def plugin_path() -> Path:
     """Absolute path to the Houdini plugin directory.
@@ -62,10 +69,17 @@ def package_json(path: Path | None = None) -> str:
 def candidate_package_dirs() -> list[Path]:
     """Plausible Houdini packages directories that already exist.
 
-    Only reports directories present on disk, and never picks one: on Windows
-    with OneDrive's Documents redirection, a desktop-launched Houdini and a
-    shell-launched one resolve different preference directories, and choosing
-    wrongly reproduces the silent no-op this command exists to prevent.
+    Only reports directories present on disk, and reports all of them rather
+    than picking. Picking was never the right shape: on Windows with OneDrive's
+    Documents redirection, a desktop-launched Houdini and a shell-launched one
+    resolve different preference directories, and there is no way to tell from
+    here which one will be read. ``install`` writes to every entry returned,
+    which makes the question moot rather than answered.
+
+    A directory only appears once it exists. A Houdini that has never been run,
+    or one whose ``packages`` directory has not been created, is invisible here,
+    and that is deliberate: creating it would mean guessing at a preference
+    directory Houdini may never read.
     """
     home = Path.home()
     roots: list[Path] = []
@@ -170,7 +184,7 @@ def write_package(destination: Path, path: Path | None = None) -> Path:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        prog="fxhoudinimcp houdini-package",
+        prog=f"{CLI} houdini-package",
         description="Print or write the Houdini package file for this install.",
     )
     parser.add_argument(
@@ -241,7 +255,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"    {candidate}")
         print(
             f"\nWrite it with:\n"
-            f"    fxhoudinimcp houdini-package --write \"{candidates[0]}\""
+            f"    {CLI} houdini-package --write \"{candidates[0]}\""
         )
     else:
         print(

--- a/python/fxhoudinimcp/install.py
+++ b/python/fxhoudinimcp/install.py
@@ -7,15 +7,25 @@ Every one of those steps fails quietly. Houdini skips a package file it cannot
 resolve without saying so, and Claude Desktop does not inherit your PATH, so a
 bare ``python`` in its config reads as "disconnected" with no explanation.
 
-    fxhoudinimcp install                      # do both halves
-    fxhoudinimcp install --dry-run            # say what it would do, change nothing
-    fxhoudinimcp install --houdini-dir DIR    # when the packages directory is ambiguous
-    fxhoudinimcp install --client none        # plugin only, wire the client yourself
+    python -m fxhoudinimcp install                    # do both halves
+    python -m fxhoudinimcp install --dry-run          # say what it would do
+    python -m fxhoudinimcp install --houdini-dir DIR  # just this one directory
+    python -m fxhoudinimcp install --client none      # wire the client yourself
 
-The Houdini destination is still not guessed when it is genuinely ambiguous. One
-candidate means there is nothing to choose and it is used; several means the
-operator picks, because choosing wrongly on Windows with OneDrive's Documents
-redirection recreates the silent no-op this command exists to prevent.
+It asks nothing and it finishes. Two earlier versions did neither, in ways worth
+recording because both looked reasonable:
+
+- It refused to choose between candidate packages directories, and exited. The
+  reasoning was sound, that a wrong choice is silent, and the conclusion was
+  wrong, because writing the same file into all of them is never a wrong choice.
+- It reported a Claude Code entry pointing somewhere else, printed the two
+  commands to repair it, and stopped. It knew both values and had already been
+  told to install. Printing homework is not finishing.
+
+What remains genuinely undecidable is still refused, not guessed: if no Houdini
+packages directory exists at all, this says so rather than inventing one, since
+a package file in a directory Houdini never reads is the silent no-op the whole
+command exists to prevent.
 """
 
 from __future__ import annotations
@@ -32,6 +42,7 @@ from pathlib import Path
 
 # Internal
 from fxhoudinimcp.houdini_package import (
+    CLI,
     PACKAGE_NAME,
     candidate_package_dirs,
     existing_packages,
@@ -92,78 +103,53 @@ def claude_code_add_argv(scope: str = "user") -> list[str]:
     ]
 
 
-def resolve_houdini_dir(explicit: str | None) -> tuple[Path | None, list[Path], str]:
-    """Decide where the package file goes.
+def claude_code_remove_argv(scope: str = "user") -> list[str]:
+    """The `claude mcp remove` invocation, for running or for printing.
 
-    Returns (chosen, candidates, reason). *chosen* is None when the operator has
-    to decide, with *reason* explaining why rather than making it up.
+    Lives next to its counterpart because `install` needs it too: `claude mcp
+    add` cannot update an entry in place, so repointing one means removing it
+    first. `uninstall` imports it from here.
+    """
+    return ["claude", "mcp", "remove", SERVER_NAME, "-s", scope]
+
+
+def printable_argv(argv: list[str]) -> str:
+    """An argv a person can paste back into a shell."""
+    return " ".join(f'"{part}"' if " " in part else part for part in argv)
+
+
+def resolve_houdini_dirs(explicit: str | None) -> tuple[list[Path], str]:
+    """Where the package file goes. An empty list means there is nowhere yet.
+
+    Every candidate, not one of them. This went through two wrong answers before
+    landing here, and the reasoning matters because it looks like carelessness.
+
+    The original code refused to choose, on the grounds that choosing wrongly is
+    invisible: Houdini skips a package file it cannot resolve without a word, so
+    the wrong directory produces silence rather than an error. True, and it made
+    the command exit rather than finish. The second answer was to ask, which
+    only moved the decision without removing it, and made the whole thing depend
+    on there being a terminal.
+
+    Both missed that the premise does not apply to "all of them". The files are
+    byte-identical and point at the same plugin, so whichever directory Houdini
+    reads, it finds a correct one. There is no last-one-wins hazard between
+    copies of the same file, which is the only reason ambiguity was dangerous.
+    OneDrive's Documents redirection stops being a question to answer and
+    becomes two paths that both work.
+
+    The cost is an MCP menu in a Houdini version you may not use, removable in
+    one `uninstall`. That is a much smaller price than a command that stops.
     """
     if explicit:
-        return Path(explicit).expanduser(), [], "given on the command line"
+        return [Path(explicit).expanduser()], "given on the command line"
 
     candidates = candidate_package_dirs()
     if not candidates:
-        return None, [], "no Houdini packages directory exists yet"
+        return [], "no Houdini packages directory exists yet"
     if len(candidates) == 1:
-        return candidates[0], candidates, "the only candidate on this machine"
-    return None, candidates, f"{len(candidates)} candidates, so the choice is yours"
-
-
-def stdin_is_interactive() -> bool:
-    """Whether there is a person on the other end who can answer a question.
-
-    Not cosmetic. This command is also run from Houdini's MCP menu and from
-    setup scripts, where stdin is not a terminal and ``input()`` either raises
-    immediately or blocks forever with a prompt nobody can see. Those callers
-    keep the printed list and the non-zero exit.
-    """
-    try:
-        return sys.stdin is not None and sys.stdin.isatty()
-    except ValueError:  # stdin closed underneath us
-        return False
-
-
-def prompt_for_package_dirs(candidates: list[Path]) -> list[Path]:
-    """Ask which packages directories to write into. Empty means cancelled.
-
-    Refusing to guess was right, but it is only half an answer: the command knew
-    the candidates, printed them, and then made the operator retype one. Asking
-    costs nothing and removes the transcription error.
-
-    "All of them" is offered because several candidates usually means several
-    Houdini versions rather than one ambiguous location. Someone running 21.0
-    and 22.0 wants the menu in both, and two runs is an invitation to do one.
-    """
-    print("  Several Houdini packages directories exist.")
-    print("  Which does the Houdini you want to use read?")
-    for index, candidate in enumerate(candidates, start=1):
-        print(f"      {index}) {candidate}")
-    print("      a) all of them")
-    print("      q) cancel")
-    print(
-        "\n  On Windows with OneDrive redirecting Documents, a desktop-launched\n"
-        "  Houdini and a shell-launched one can disagree. Start Houdini with\n"
-        "  HOUDINI_PACKAGE_VERBOSE=1 to see which it reads."
-    )
-
-    choices = f"1-{len(candidates)}" if len(candidates) > 1 else "1"
-    while True:
-        try:
-            answer = input(f"  Choose [{choices}/a/q]: ").strip().lower()
-        except EOFError:
-            # A piped stdin that runs dry. Looping would hang.
-            print()
-            return []
-        if answer == "q":
-            return []
-        if answer == "a":
-            return list(candidates)
-        if answer.isdigit() and 1 <= int(answer) <= len(candidates):
-            return [candidates[int(answer) - 1]]
-        if answer:
-            print(f"  Not one of the choices: {answer!r}")
-        else:
-            print("  Not one of the choices: nothing was entered")
+        return candidates, "the only candidate on this machine"
+    return candidates, f"every candidate on this machine ({len(candidates)})"
 
 
 def _merge_desktop_config(existing: dict, command: list[str]) -> dict:
@@ -284,10 +270,61 @@ def claude_code_current_command() -> str | None:
     return None
 
 
+def _first_line(result: subprocess.CompletedProcess) -> str:
+    """The most useful single line out of a failed subprocess."""
+    output = (result.stderr or "") + (result.stdout or "")
+    detail = output.strip().splitlines()
+    return detail[0] if detail else f"exit code {result.returncode}"
+
+
+def repoint_claude_code() -> list[str]:
+    """Replace a Claude Code entry that points at a different interpreter.
+
+    `claude mcp add` has no --force, so an existing entry is an error rather
+    than an update. This used to be reported back with the two commands needed
+    to fix it, which was the installer declining to finish its own job: it knows
+    the value that is there, it knows the one that should be, and the operator
+    consented by running `install`. Printing homework instead is the same "four
+    steps across two worlds" this command exists to remove.
+
+    Removing first is safe in a way a blind overwrite would not be, because the
+    old value is read and reported before anything changes.
+    """
+    current = claude_code_current_command()
+    wanted = client_command()[0]
+    if current == wanted:
+        return ["  Claude Code already points at this Python. Nothing to do."]
+
+    removal = claude_code_remove_argv()
+    result = subprocess.run(removal, capture_output=True, text=True)
+    if result.returncode != 0:
+        return [
+            f"  Claude Code has '{SERVER_NAME}' pointing at "
+            f"{current or '<could not read it>'},",
+            f"  and it could not be replaced: {_first_line(result)}",
+            f"  Remove it by hand, then re-run: {printable_argv(removal)}",
+        ]
+
+    argv = claude_code_add_argv()
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        return [
+            f"  Removed the old '{SERVER_NAME}' entry, but re-registering "
+            f"failed: {_first_line(result)}",
+            f"  Finish it with: {printable_argv(argv)}",
+        ]
+
+    return [
+        f"  Repointed '{SERVER_NAME}' in Claude Code (user scope):",
+        f"      was: {current or '<could not read it>'}",
+        f"      now: {wanted}",
+    ]
+
+
 def install_claude_code(dry_run: bool) -> list[str]:
     """Register with Claude Code via its own CLI. Returns report lines."""
     argv = claude_code_add_argv()
-    printable = " ".join(f'"{part}"' if " " in part else part for part in argv)
+    printable = printable_argv(argv)
 
     if not claude_code_available():
         return [
@@ -305,30 +342,11 @@ def install_claude_code(dry_run: bool) -> list[str]:
         return [f"  Registered '{SERVER_NAME}' with Claude Code (user scope)."]
 
     output = (result.stderr or "") + (result.stdout or "")
-    detail = output.strip().splitlines()
-    first = detail[0] if detail else f"exit code {result.returncode}"
-
-    # `claude mcp add` has no --force, so re-running over an existing entry is
-    # an error rather than an update. That is not a problem when the entry is
-    # already correct, and reporting "failed" there sends people chasing a
-    # non-issue, so check what is actually registered before saying anything.
     if "already exists" in output.lower():
-        current = claude_code_current_command()
-        wanted = client_command()[0]
-        if current == wanted:
-            return ["  Claude Code already points at this Python. Nothing to do."]
-        return [
-            f"  Claude Code already has '{SERVER_NAME}', pointing at:",
-            f"      {current or '<could not read it>'}",
-            "  This install is:",
-            f"      {wanted}",
-            "  It cannot be updated in place, so repoint it with:",
-            f"      claude mcp remove {SERVER_NAME} -s user",
-            "      fxhoudinimcp install --client-only",
-        ]
+        return repoint_claude_code()
 
     return [
-        f"  Claude Code registration failed: {first}",
+        f"  Claude Code registration failed: {_first_line(result)}",
         f"  Run it yourself to see the whole error: {printable}",
     ]
 
@@ -341,7 +359,7 @@ def build_parser() -> argparse.ArgumentParser:
     compares the two.
     """
     parser = argparse.ArgumentParser(
-        prog="fxhoudinimcp install",
+        prog=f"{CLI} install",
         description="Install the Houdini plugin and register this server "
         "with your MCP client.",
     )
@@ -426,51 +444,19 @@ def _report_missing_directory(destination: Path) -> None:
     print("  Create it first, or pass a different --houdini-dir.", file=sys.stderr)
 
 
-def _choose_destinations(args) -> tuple[list[Path], str] | None:
-    """Work out where the package file goes. None means stop, non-zero exit."""
-    chosen, candidates, reason = resolve_houdini_dir(args.houdini_dir)
+def _install_plugin_half(args, plugin: Path) -> int:
+    """Write the Houdini package file. Returns an exit code."""
+    print("Houdini plugin")
 
-    if chosen is not None:
-        return [chosen], reason
-
-    if not candidates:
+    destinations, reason = resolve_houdini_dirs(args.houdini_dir)
+    if not destinations:
         print(f"  {reason.capitalize()}.")
         print(
             "  Create one inside your Houdini preferences directory, for "
             "example\n      Documents/houdini22.0/packages\n"
             "  then re-run this command."
         )
-        return None
-
-    if not stdin_is_interactive():
-        print(f"  Cannot choose for you: {reason}.")
-        for candidate in candidates:
-            print(f"      {candidate}")
-        print("\n  Re-run with the one your Houdini actually reads:")
-        print(f'      fxhoudinimcp install --houdini-dir "{candidates[0]}"')
-        print(
-            "\n  On Windows with OneDrive redirecting Documents, a "
-            "desktop-launched\n  Houdini and a shell-launched one can "
-            "disagree. Start Houdini with\n  HOUDINI_PACKAGE_VERBOSE=1 to "
-            "see which it reads."
-        )
-        return None
-
-    destinations = prompt_for_package_dirs(candidates)
-    if not destinations:
-        print("  Cancelled. Nothing was written.")
-        return None
-    return destinations, "chosen at the prompt"
-
-
-def _install_plugin_half(args, plugin: Path) -> int:
-    """Write the Houdini package file. Returns an exit code."""
-    print("Houdini plugin")
-
-    resolved = _choose_destinations(args)
-    if resolved is None:
         return 1
-    destinations, reason = resolved
 
     # Every destination is checked before any is written, so a typo in the
     # second one cannot leave the first half-installed. It also keeps --dry-run

--- a/python/fxhoudinimcp/uninstall.py
+++ b/python/fxhoudinimcp/uninstall.py
@@ -39,18 +39,27 @@ import sys
 from pathlib import Path
 
 # Internal
-from fxhoudinimcp.houdini_package import PACKAGE_NAME, existing_packages
+from fxhoudinimcp.houdini_package import CLI, PACKAGE_NAME, existing_packages
 from fxhoudinimcp.install import (
     SERVER_NAME,
     claude_code_available,
+    claude_code_remove_argv,
     desktop_config_path,
-    stdin_is_interactive,
 )
 
 
-def claude_code_remove_argv(scope: str = "user") -> list[str]:
-    """The `claude mcp remove` invocation, for running or for printing."""
-    return ["claude", "mcp", "remove", SERVER_NAME, "-s", scope]
+def stdin_is_interactive() -> bool:
+    """Whether there is a person on the other end who can answer a question.
+
+    This lives here rather than in ``install`` because deleting files is now the
+    only question left worth asking. ``install`` used to ask which Houdini
+    packages directory to use and no longer does, having concluded the question
+    was avoidable; this one is not.
+    """
+    try:
+        return sys.stdin is not None and sys.stdin.isatty()
+    except ValueError:  # stdin closed underneath us
+        return False
 
 
 def find_package_files(houdini_dir: str | None) -> list[Path]:
@@ -173,7 +182,7 @@ def remove_claude_code(dry_run: bool) -> list[str]:
 def build_parser() -> argparse.ArgumentParser:
     """The argument parser, exposed so the README's flag table can be checked."""
     parser = argparse.ArgumentParser(
-        prog="fxhoudinimcp uninstall",
+        prog=f"{CLI} uninstall",
         description="Remove the Houdini package file and the MCP client "
         "registration written by `fxhoudinimcp install`.",
     )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -80,46 +80,82 @@ def test_claude_code_argv_separates_options_from_command():
 
 def test_explicit_dir_wins(monkeypatch):
     monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [Path("/ignored")])
-    chosen, _, _ = inst.resolve_houdini_dir("~/somewhere")
-    assert chosen == Path("~/somewhere").expanduser()
+    chosen, _ = inst.resolve_houdini_dirs("~/somewhere")
+    assert chosen == [Path("~/somewhere").expanduser()]
 
 
 def test_single_candidate_is_used(monkeypatch, tmp_path):
-    """One candidate means there is nothing to choose, so do not make the user."""
     monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [tmp_path])
-    chosen, candidates, _ = inst.resolve_houdini_dir(None)
-    assert chosen == tmp_path
-    assert candidates == [tmp_path]
+    chosen, _ = inst.resolve_houdini_dirs(None)
+    assert chosen == [tmp_path]
 
 
-def test_several_candidates_refuse_to_guess(monkeypatch, tmp_path):
-    """The OneDrive redirection case. Guessing recreates a silent no-op.
+def test_several_candidates_all_get_written(monkeypatch, tmp_path):
+    """The OneDrive case stops being a question once the answer is "both".
 
     A desktop-launched Houdini and a shell-launched one can resolve different
     preference directories on Windows, and Houdini reports nothing when it skips
-    a package file, so the wrong guess is invisible.
+    a package file, so a wrong single choice is invisible. Writing the same file
+    into every candidate cannot be wrong: they are byte-identical and point at
+    the same plugin, so whichever one Houdini reads is correct.
     """
     first, second = tmp_path / "a", tmp_path / "b"
     monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [first, second])
-    chosen, candidates, reason = inst.resolve_houdini_dir(None)
-    assert chosen is None
-    assert candidates == [first, second]
-    assert "2 candidates" in reason
+
+    chosen, reason = inst.resolve_houdini_dirs(None)
+
+    assert chosen == [first, second]
+    assert "every candidate" in reason
 
 
-def test_ambiguous_dir_exits_nonzero_and_writes_nothing(
+def test_several_candidates_install_into_all_of_them(
     plugin_dir, tmp_path, monkeypatch, capsys
 ):
+    """End to end: no prompt, no refusal, both files written."""
     first, second = tmp_path / "a", tmp_path / "b"
     first.mkdir()
     second.mkdir()
     monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [first, second])
     monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
 
+    assert inst.main(["--client", "none"]) == 0
+
+    assert (first / "fxhoudinimcp.json").is_file()
+    assert (second / "fxhoudinimcp.json").is_file()
+    assert "Cannot choose for you" not in capsys.readouterr().out
+
+
+def test_installing_never_reads_stdin(plugin_dir, tmp_path, monkeypatch):
+    """The whole command must work with no terminal attached.
+
+    It is run from Houdini's MCP menu, from setup scripts and from CI, and an
+    earlier version that stopped to ask made all three impossible. Reaching
+    input() at all is the failure.
+    """
+    first, second = tmp_path / "a", tmp_path / "b"
+    first.mkdir()
+    second.mkdir()
+    monkeypatch.setattr(inst, "candidate_package_dirs", lambda: [first, second])
+    monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
+    monkeypatch.setattr(inst, "claude_code_available", lambda: False)
+    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
+
+    def explode(prompt: str = "") -> str:
+        raise AssertionError("install must never block on input()")
+
+    monkeypatch.setattr("builtins.input", explode)
+
+    assert inst.main([]) == 0
+
+
+def test_no_candidates_is_still_refused(plugin_dir, isolated, capsys):
+    """The one thing left that genuinely cannot be worked out.
+
+    Inventing a directory would put the package file somewhere Houdini never
+    reads, which is the silent no-op the command exists to prevent.
+    """
     assert inst.main([]) == 1
-    assert not list(first.iterdir())
-    assert not list(second.iterdir())
-    assert "Cannot choose for you" in capsys.readouterr().out
+    assert "no houdini packages directory exists yet" in capsys.readouterr().out.lower()
 
 
 def test_writes_package_into_chosen_dir(plugin_dir, isolated, tmp_path, capsys):
@@ -354,42 +390,6 @@ def _fails_with(message: str):
     return fake_run
 
 
-def test_already_registered_and_correct_is_not_reported_as_failure(monkeypatch):
-    """`claude mcp add` has no --force, so re-running is an error.
-
-    That is not a problem when the entry already points at this Python, and
-    calling it a failure sends people chasing a non-issue.
-    """
-    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
-    monkeypatch.setattr(
-        inst.subprocess, "run", _fails_with("MCP server fxhoudini already exists")
-    )
-    monkeypatch.setattr(
-        inst, "claude_code_current_command", lambda: inst.client_command()[0]
-    )
-
-    lines = inst.install_claude_code(dry_run=False)
-
-    assert any("Nothing to do" in line for line in lines)
-    assert not any("failed" in line.lower() for line in lines)
-
-
-def test_already_registered_elsewhere_shows_both_paths(monkeypatch):
-    """Repointing needs remove-then-add, and the user needs to see why."""
-    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
-    monkeypatch.setattr(
-        inst.subprocess, "run", _fails_with("MCP server fxhoudini already exists")
-    )
-    monkeypatch.setattr(inst, "claude_code_current_command", lambda: "/other/python")
-
-    lines = inst.install_claude_code(dry_run=False)
-    joined = "\n".join(lines)
-
-    assert "/other/python" in joined
-    assert inst.client_command()[0] in joined
-    assert f"claude mcp remove {inst.SERVER_NAME}" in joined
-
-
 def test_genuine_failure_is_reported(monkeypatch):
     monkeypatch.setattr(inst, "claude_code_available", lambda: True)
     monkeypatch.setattr(inst.subprocess, "run", _fails_with("disk on fire"))
@@ -450,25 +450,7 @@ def test_claude_code_success(monkeypatch):
     assert any("Registered" in line for line in lines)
 
 
-###### Choosing between several candidates, at the prompt
-
-
-def _answers(monkeypatch, *replies: str) -> None:
-    """Feed *replies* to input() in order, then behave like a closed stdin."""
-    pending = list(replies)
-
-    def fake_input(prompt: str = "") -> str:
-        if not pending:
-            raise EOFError
-        return pending.pop(0)
-
-    monkeypatch.setattr("builtins.input", fake_input)
-
-
-@pytest.fixture
-def interactive(monkeypatch):
-    """A terminal on the other end, so the installer is allowed to ask."""
-    monkeypatch.setattr(inst, "stdin_is_interactive", lambda: True)
+###### Repointing a client entry instead of reporting it
 
 
 @pytest.fixture
@@ -484,134 +466,108 @@ def two_candidates(monkeypatch, tmp_path):
     return first, second
 
 
-def test_prompt_lists_every_candidate(monkeypatch, tmp_path, capsys):
-    first, second = tmp_path / "a", tmp_path / "b"
-    _answers(monkeypatch, "1")
+def _runs(monkeypatch, *results: int) -> list[list[str]]:
+    """Record every subprocess argv, returning *results* in order."""
+    calls: list[list[str]] = []
+    codes = list(results)
 
-    assert inst.prompt_for_package_dirs([first, second]) == [first]
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        code = codes.pop(0) if codes else 0
+        stderr = "MCP server fxhoudini already exists" if code == 1 else ""
+        return subprocess.CompletedProcess(argv, code, stdout="", stderr=stderr)
 
-    out = capsys.readouterr().out
-    assert str(first) in out
-    assert str(second) in out
-
-
-def test_prompt_returns_the_numbered_choice(monkeypatch, tmp_path):
-    first, second = tmp_path / "a", tmp_path / "b"
-    _answers(monkeypatch, "2")
-    assert inst.prompt_for_package_dirs([first, second]) == [second]
+    monkeypatch.setattr(inst.subprocess, "run", fake_run)
+    return calls
 
 
-def test_prompt_can_take_all_of_them(monkeypatch, tmp_path):
-    """Several candidates is usually several Houdini versions, not ambiguity.
+def test_a_stale_entry_is_repointed_not_reported(monkeypatch, capsys):
+    """The defect this replaces: it printed two commands and made you run them.
 
-    Someone running 21.0 and 22.0 side by side wants the menu in both, and
-    making them run the command twice invites doing it once and forgetting.
+    `claude mcp add` has no --force, so an existing entry is an error rather
+    than an update. The installer knows the old value, knows the new one, and
+    was told to install. Handing back homework is not finishing the job.
     """
-    first, second = tmp_path / "a", tmp_path / "b"
-    _answers(monkeypatch, "a")
-    assert inst.prompt_for_package_dirs([first, second]) == [first, second]
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(inst, "claude_code_current_command", lambda: "python")
+    calls = _runs(monkeypatch, 1, 0, 0)  # add fails, remove works, add works
+
+    lines = inst.install_claude_code(dry_run=False)
+
+    assert calls[0][:3] == ["claude", "mcp", "add"]
+    assert calls[1][:3] == ["claude", "mcp", "remove"]
+    assert calls[2][:3] == ["claude", "mcp", "add"]
+    joined = " ".join(lines)
+    assert "Repointed" in joined
+    assert "python" in joined  # the old value is named, not silently dropped
+    assert inst.client_command()[0] in joined
 
 
-def test_prompt_can_be_cancelled(monkeypatch, tmp_path):
-    _answers(monkeypatch, "q")
-    assert inst.prompt_for_package_dirs([tmp_path / "a", tmp_path / "b"]) == []
+def test_an_already_correct_entry_is_left_alone(monkeypatch):
+    """Nothing to repoint, and nothing removed: no churn on a good config."""
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        inst, "claude_code_current_command", lambda: inst.client_command()[0]
+    )
+    calls = _runs(monkeypatch, 1)
+
+    lines = inst.install_claude_code(dry_run=False)
+
+    assert [c[:3] for c in calls] == [["claude", "mcp", "add"]]
+    assert any("Nothing to do" in line for line in lines)
 
 
-def test_prompt_treats_end_of_input_as_cancel(monkeypatch, tmp_path):
-    """A piped stdin that runs dry must not loop forever."""
-    _answers(monkeypatch)
-    assert inst.prompt_for_package_dirs([tmp_path / "a", tmp_path / "b"]) == []
+def test_a_failed_removal_does_not_claim_success(monkeypatch):
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(inst, "claude_code_current_command", lambda: "python")
+
+    def fake_run(argv, **kwargs):
+        # The add has to fail the way Claude Code actually fails, or the
+        # repoint branch is never reached and the test proves nothing.
+        if "remove" in argv:
+            return subprocess.CompletedProcess(argv, 1, stdout="", stderr="denied")
+        return subprocess.CompletedProcess(
+            argv, 1, stdout="", stderr="MCP server fxhoudini already exists"
+        )
+
+    monkeypatch.setattr(inst.subprocess, "run", fake_run)
+
+    lines = inst.install_claude_code(dry_run=False)
+
+    joined = " ".join(lines)
+    assert "could not be replaced" in joined
+    assert "Repointed" not in joined
 
 
-def test_prompt_re_asks_rather_than_guessing(monkeypatch, tmp_path, capsys):
-    """Out of range, not a number, and empty are all re-asked, never rounded."""
-    first, second = tmp_path / "a", tmp_path / "b"
-    _answers(monkeypatch, "3", "yes", "", "1")
+def test_a_failed_re_add_says_the_entry_is_gone(monkeypatch):
+    """Worst case, and the one that must not be silent: removed, not re-added."""
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(inst, "claude_code_current_command", lambda: "python")
+    _runs(monkeypatch, 1, 0, 1)  # add fails, remove works, re-add fails
 
-    assert inst.prompt_for_package_dirs([first, second]) == [first]
+    lines = inst.install_claude_code(dry_run=False)
 
-    out = capsys.readouterr().out
-    assert out.count("Not one of the choices") == 3
-    assert "nothing was entered" in out  # a bare Return is rejected, not defaulted
-
-
-def test_ambiguous_dir_prompts_and_writes_only_the_choice(
-    plugin_dir, interactive, two_candidates, monkeypatch
-):
-    first, second = two_candidates
-    _answers(monkeypatch, "2")
-
-    assert inst.main(["--client", "none"]) == 0
-
-    assert not list(first.iterdir())
-    assert (second / "fxhoudinimcp.json").is_file()
+    joined = " ".join(lines)
+    assert "Removed the old" in joined
+    assert "Finish it with" in joined
 
 
-def test_choosing_all_writes_into_every_candidate(
-    plugin_dir, interactive, two_candidates, monkeypatch
-):
-    first, second = two_candidates
-    _answers(monkeypatch, "a")
-
-    assert inst.main(["--client", "none"]) == 0
-
-    assert (first / "fxhoudinimcp.json").is_file()
-    assert (second / "fxhoudinimcp.json").is_file()
-
-
-def test_cancelling_writes_nothing_and_exits_nonzero(
-    plugin_dir, interactive, two_candidates, monkeypatch, capsys
-):
-    first, second = two_candidates
-    _answers(monkeypatch, "q")
-
-    assert inst.main(["--client", "none"]) == 1
-
-    assert not list(first.iterdir())
-    assert not list(second.iterdir())
-    assert "Cancelled" in capsys.readouterr().out
-
-
-def test_a_non_interactive_run_never_stops_to_ask(
-    plugin_dir, two_candidates, monkeypatch, capsys
-):
-    """The MCP menu and any script run this with no terminal attached.
-
-    input() there either raises immediately or blocks forever, and a Houdini
-    menu item that hangs on a prompt nobody can see is worse than one that
-    prints instructions. So the old list-and-refuse behaviour is kept, and
-    reaching input() at all is treated as the failure it would be.
-    """
-    monkeypatch.setattr(inst, "stdin_is_interactive", lambda: False)
-
-    def explode(prompt: str = "") -> str:
-        raise AssertionError("a non-interactive install must not call input()")
-
-    monkeypatch.setattr("builtins.input", explode)
-    first, second = two_candidates
-
-    assert inst.main(["--client", "none"]) == 1
-
-    assert not list(first.iterdir())
-    assert not list(second.iterdir())
-    assert "Cannot choose for you" in capsys.readouterr().out
-
-
-def test_an_explicit_dir_never_prompts(plugin_dir, interactive, tmp_path, monkeypatch):
-    """--houdini-dir already answered the question."""
-    packages = tmp_path / "packages"
-    packages.mkdir()
-    monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
+def test_no_message_recommends_the_bare_console_script(monkeypatch):
+    """The README says use the module form; our errors used to contradict it."""
     monkeypatch.setattr(inst, "claude_code_available", lambda: False)
-    monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
 
-    def explode(prompt: str = "") -> str:
-        raise AssertionError("--houdini-dir must not be second-guessed")
+    for line in inst.install_claude_code(dry_run=False):
+        assert not line.strip().startswith("fxhoudinimcp ")
 
-    monkeypatch.setattr("builtins.input", explode)
 
-    assert inst.main(["--houdini-dir", str(packages), "--client", "none"]) == 0
-    assert (packages / "fxhoudinimcp.json").is_file()
+def test_every_parser_spells_itself_the_module_way():
+    # Internal
+    from fxhoudinimcp import houdini_package as hp_mod
+    from fxhoudinimcp import uninstall as uninst
+
+    for parser in (inst.build_parser(), uninst.build_parser()):
+        assert parser.prog.startswith("python -m fxhoudinimcp")
+    assert hp_mod.CLI == "python -m fxhoudinimcp"
 
 
 ###### A dry run has to be honest about what would fail
@@ -632,7 +588,7 @@ def test_dry_run_rejects_a_directory_that_does_not_exist(
 
 
 def test_nothing_is_written_when_one_destination_is_missing(
-    plugin_dir, interactive, monkeypatch, tmp_path
+    plugin_dir, monkeypatch, tmp_path
 ):
     """Every destination is checked before the first one is written."""
     first, second = tmp_path / "a", tmp_path / "b"
@@ -641,14 +597,12 @@ def test_nothing_is_written_when_one_destination_is_missing(
     monkeypatch.setattr(inst, "existing_packages", lambda exclude=None: [])
     monkeypatch.setattr(inst, "claude_code_available", lambda: False)
     monkeypatch.setattr(inst, "desktop_config_path", lambda: None)
-    _answers(monkeypatch, "a")
-
     assert inst.main(["--client", "none"]) == 1
     assert not list(first.iterdir())
 
 
 def test_the_files_just_written_are_not_reported_as_leftovers(
-    plugin_dir, interactive, two_candidates, monkeypatch, capsys
+    plugin_dir, two_candidates, monkeypatch, capsys
 ):
     """Writing both and then warning about both would be self-contradictory.
 
@@ -658,8 +612,6 @@ def test_the_files_just_written_are_not_reported_as_leftovers(
     first, second = two_candidates
     monkeypatch.setattr(inst, "existing_packages", hp.existing_packages)
     monkeypatch.setattr(hp, "candidate_package_dirs", lambda: [first, second])
-    _answers(monkeypatch, "a")
-
     assert inst.main(["--client", "none"]) == 0
     assert "WARNING" not in capsys.readouterr().out
 


### PR DESCRIPTION
Reported as "this whole process is convoluted, most MCPs are a one line
installer". Fair. A real run ended with a prompt and then two commands to type:

```
  Choose [1-2/a/q]: a
  ...
MCP client
  Claude Code already has 'fxhoudini', pointing at:
      python
  It cannot be updated in place, so repoint it with:
      claude mcp remove fxhoudini -s user
      fxhoudinimcp install --client-only
```

Three failures, two of them shipped in 2.5.0 an hour earlier.

### The prompt should not have existed

It replaced a refusal, and both were answers to a question that does not need
asking. Refusing was justified by "a wrong choice is silent", since Houdini
skips a package file it cannot resolve without a word. True, and it does not
apply to *all of them*: the files are byte-identical and point at the same
plugin, so whichever directory Houdini reads, it finds a correct one. There is
no last-one-wins hazard between copies of the same file, which was the only
reason ambiguity was dangerous. OneDrive's Documents redirection stops being a
question and becomes two paths that both work.

`install` now writes to every candidate and asks nothing, so it behaves
identically from a terminal, from Houdini's MCP menu, and from a script.
`--houdini-dir` still narrows it. What is genuinely undecidable, no packages
directory existing at all, is still refused rather than guessed.

### The client half punted

`claude mcp add` has no `--force`, so an existing entry is an error rather than
an update. That was reported back with the repair commands, which is the
installer declining to finish its own job. It now removes and re-adds, printing
both values so nothing changes silently, and covers the failure modes including
the bad one: removed but not re-added.

### Its advice contradicted the docs

It printed `fxhoudinimcp install --client-only`, the bare console script the
README warns against for exactly the multi-Python reason this project keeps
hitting. Every self-referential command now uses the module form, from one
constant, with a test pinning it.

### Verification

- 361 tests pass. The prompt's tests are replaced by ones asserting `install`
  never reaches `input()`.
- Dry-run against a real two-Houdini machine with stdin closed: no prompt, exit
  0, both directories reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
