### PR TITLE
Say which config file the client registration was written to

### DIFF
--- a/python/fxhoudinimcp/install.py
+++ b/python/fxhoudinimcp/install.py
@@ -277,6 +277,34 @@ def _first_line(result: subprocess.CompletedProcess) -> str:
     return detail[0] if detail else f"exit code {result.returncode}"
 
 
+def config_file_note(result: subprocess.CompletedProcess) -> list[str]:
+    """Name the config file the Claude Code CLI actually wrote.
+
+    It already prints ``File modified: <path>`` and we were swallowing it, in
+    favour of "registered with Claude Code (user scope)". That reads as complete
+    and is not, because "user scope" is not one place: CLAUDE_CONFIG_DIR decides
+    which profile is user scope, and a machine can have several. On one with a
+    second profile, a correct, connected registration was invisible to every
+    `claude mcp get` run from the other one, and looked like a failed install
+    for an afternoon.
+
+    Naming the file costs one line and removes the ambiguity, so a report of
+    success can be checked rather than believed.
+    """
+    output = (result.stdout or "") + (result.stderr or "")
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.lower().startswith("file modified:"):
+            return [f"      in {stripped.split(':', 1)[1].strip()}"]
+
+    # Older CLIs may not print it. Naming the profile is still better than
+    # silence, and it is read from the environment rather than guessed.
+    profile = os.environ.get("CLAUDE_CONFIG_DIR")
+    if profile:
+        return [f"      in the Claude Code profile at {profile}"]
+    return []
+
+
 def repoint_claude_code() -> list[str]:
     """Replace a Claude Code entry that points at a different interpreter.
 
@@ -318,6 +346,7 @@ def repoint_claude_code() -> list[str]:
         f"  Repointed '{SERVER_NAME}' in Claude Code (user scope):",
         f"      was: {current or '<could not read it>'}",
         f"      now: {wanted}",
+        *config_file_note(result),
     ]
 
 
@@ -339,7 +368,10 @@ def install_claude_code(dry_run: bool) -> list[str]:
     # ~/.claude.json directly and risking a shape this version does not expect.
     result = subprocess.run(argv, capture_output=True, text=True)
     if result.returncode == 0:
-        return [f"  Registered '{SERVER_NAME}' with Claude Code (user scope)."]
+        return [
+            f"  Registered '{SERVER_NAME}' with Claude Code (user scope).",
+            *config_file_note(result),
+        ]
 
     output = (result.stderr or "") + (result.stdout or "")
     if "already exists" in output.lower():

--- a/python/fxhoudinimcp/uninstall.py
+++ b/python/fxhoudinimcp/uninstall.py
@@ -44,6 +44,7 @@ from fxhoudinimcp.install import (
     SERVER_NAME,
     claude_code_available,
     claude_code_remove_argv,
+    config_file_note,
     desktop_config_path,
 )
 
@@ -163,7 +164,10 @@ def remove_claude_code(dry_run: bool) -> list[str]:
 
     result = subprocess.run(argv, capture_output=True, text=True)
     if result.returncode == 0:
-        return [f"  Removed '{SERVER_NAME}' from Claude Code (user scope)."]
+        return [
+            f"  Removed '{SERVER_NAME}' from Claude Code (user scope).",
+            *config_file_note(result),
+        ]
 
     output = (result.stderr or "") + (result.stdout or "")
     # Removing something that is not there is the desired end state, not a

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -560,6 +560,80 @@ def test_no_message_recommends_the_bare_console_script(monkeypatch):
         assert not line.strip().startswith("fxhoudinimcp ")
 
 
+###### Saying which config was written
+
+
+_MODIFIED = "Added stdio MCP server fxhoudini\nFile modified: C:\\Users\\me\\.claude.json\n"
+
+
+def test_success_names_the_config_file(monkeypatch):
+    """"Registered with Claude Code (user scope)" is not a checkable claim.
+
+    CLAUDE_CONFIG_DIR decides which profile is user scope, and a machine can
+    have several. A correct, connected registration in one was invisible to
+    every `claude mcp get` run from the other, and read as a failed install.
+    The CLI already prints the path; swallowing it was the whole problem.
+    """
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        inst.subprocess,
+        "run",
+        lambda argv, **kw: subprocess.CompletedProcess(argv, 0, stdout=_MODIFIED),
+    )
+
+    lines = inst.install_claude_code(dry_run=False)
+
+    assert any("C:\\Users\\me\\.claude.json" in line for line in lines)
+
+
+def test_a_windows_drive_letter_survives_the_parse():
+    """The path has a colon in it, so splitting on every colon would truncate."""
+    result = subprocess.CompletedProcess([], 0, stdout=_MODIFIED)
+    assert inst.config_file_note(result) == ["      in C:\\Users\\me\\.claude.json"]
+
+
+def test_repointing_names_the_config_file(monkeypatch):
+    monkeypatch.setattr(inst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(inst, "claude_code_current_command", lambda: "python")
+
+    adds: list[int] = []
+
+    def fake_run(argv, **kwargs):
+        if "remove" in argv:
+            return subprocess.CompletedProcess(argv, 0, stdout="")
+        adds.append(1)
+        if len(adds) > 1:  # the re-add, after the removal
+            return subprocess.CompletedProcess(argv, 0, stdout=_MODIFIED)
+        return subprocess.CompletedProcess(
+            argv, 1, stderr="MCP server fxhoudini already exists"
+        )
+
+    monkeypatch.setattr(inst.subprocess, "run", fake_run)
+
+    lines = inst.install_claude_code(dry_run=False)
+
+    assert any("Repointed" in line for line in lines)
+    assert any("C:\\Users\\me\\.claude.json" in line for line in lines)
+
+
+def test_falls_back_to_naming_the_profile(monkeypatch):
+    """An older CLI may not print the path. The profile still beats silence."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", r"C:\Users\me\.claude-work")
+    result = subprocess.CompletedProcess([], 0, stdout="Added stdio MCP server\n")
+
+    assert inst.config_file_note(result) == [
+        r"      in the Claude Code profile at C:\Users\me\.claude-work"
+    ]
+
+
+def test_says_nothing_when_there_is_nothing_to_say(monkeypatch):
+    """One profile and a quiet CLI: do not invent a path."""
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    result = subprocess.CompletedProcess([], 0, stdout="Added stdio MCP server\n")
+
+    assert inst.config_file_note(result) == []
+
+
 def test_every_parser_spells_itself_the_module_way():
     # Internal
     from fxhoudinimcp import houdini_package as hp_mod

--- a/tests/test_uninstall.py
+++ b/tests/test_uninstall.py
@@ -356,6 +356,22 @@ def test_a_genuine_failure_is_reported(monkeypatch):
     assert any("failed" in line.lower() for line in lines)
 
 
+def test_removal_names_the_config_file(monkeypatch):
+    """Same reason as install: which profile was touched is not obvious."""
+    monkeypatch.setattr(uninst, "claude_code_available", lambda: True)
+    monkeypatch.setattr(
+        uninst.subprocess,
+        "run",
+        lambda argv, **kw: subprocess.CompletedProcess(
+            argv, 0, stdout="Removed\nFile modified: C:\\Users\\me\\.claude.json\n"
+        ),
+    )
+
+    lines = uninst.remove_claude_code(dry_run=False)
+
+    assert any("C:\\Users\\me\\.claude.json" in line for line in lines)
+
+
 def test_removal_argv_targets_the_user_scope(monkeypatch):
     """install registers at user scope, so uninstall has to look there."""
     assert uninst.claude_code_remove_argv() == [


### PR DESCRIPTION
`install` reported:

```
MCP client
  Registered 'fxhoudini' with Claude Code (user scope).
```

True, complete, and not checkable. "User scope" is not one place: `CLAUDE_CONFIG_DIR`
selects the Claude Code profile, and a machine can have more than one. On a machine
with two, a correct and **connected** registration in the first profile was invisible
to every `claude mcp get` run from the second, so a working install looked like a
broken one for an afternoon of digging.

The CLI already prints the answer, and we were throwing it away, because the output is
captured and replaced with our own line:

```
File modified: C:\Users\...\.claude-work\.claude.json
```

It is now echoed under the success line, for register, repoint and remove alike:

```
MCP client
  Registered 'fxhoudini' with Claude Code (user scope).
      in C:\Users\you\.claude.json
```

Where an older CLI does not print it, `CLAUDE_CONFIG_DIR` is named instead, read from
the environment rather than guessed. Where there is nothing to say, nothing is said,
since inventing a path would be worse than silence.

This is the same defect as the rest of this series, one step further out: an operation
that succeeded, reported vaguely, and cost more time than an outright failure would
have.

### Verification

- 367 tests pass, 6 new.
- Parser checked against the real `claude mcp add` output, not only a fixture,
  including that a Windows drive letter survives the colon split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
